### PR TITLE
Allows travis to run on new infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
   - '7'
 


### PR DESCRIPTION
Adds ```sudo: false``` to the travis-file to allow usage of the faster container-based architecture as described in https://docs.travis-ci.com/user/migrating-from-legacy/