### PR TITLE
Adds latest PHP to checked versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: php
 
 php:
   - '7'
+  - nightly
+
+matrix:
+  fast_finish : true
+  allow_failures:
+    - php: nightly
 
 install:
   - composer install


### PR DESCRIPTION
Adds the latest-version to the tested versions on travis. Therefore the latest "nightly" is also tested along with the current stable release