### PR TITLE
Added bin/composer-require-checker to Composer-managed binaries list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,22 @@ php:
   - nightly
 
 matrix:
-  fast_finish : true
+  fast_finish: true
   allow_failures:
     - php: nightly
+
+before_install:
+  - phpenv config-rm xdebug.ini || true
+  - composer self-update
+  - sed s\@TRAVIS_BUILD_DIR@$TRAVIS_BUILD_DIR@g test/travis-composer.json > ~/.composer/composer.json
 
 install:
   - composer install
 
+  - composer global require maglnet/composer-require-checker:@dev
+  - export PATH=$PATH:~/.composer/vendor/bin
+
 script:
   - vendor/bin/phpunit
-  - php bin/composer-require-checker
+
+  - composer-require-checker

--- a/README.md
+++ b/README.md
@@ -11,8 +11,40 @@ This will prevent you from using "soft" dependencies that are not defined within
 ## Usage
 
 Composer require checker is not supposed to be installed as part of your project dependencies.  
-Please check the [releases](https://github.com/maglnet/ComposerRequireChecker/releases) for available phar files or
-install it in a separate directory via:
+
+### As a global command
+
+This package can be easily globally installed by using Composer! Just run:
+
+```sh
+composer global require maglnet/composer-require-checker
+```
+
+If you haven't installed any Composer global binaries, it may be needed to customize your 
+`~/.bashrc` / `~/.zshrc` by adding Composer binaries path to your $PATH environmental variable:
+
+```sh
+PATH="$PATH:$COMPOSER_HOME/vendor/bin"
+```
+
+Then just run `source ~/.bashrc` / `source ~/.zshrc` or start a new shell, the command can be used as:
+
+```sh
+composer-require-checker check /path/to/your/project/composer.json
+```
+
+##### Troubleshooting
+
+If command can't be located, try putting `export` just before modifying `PATH` environmental variable 
+in `~/.bashrc` / `~/.zshrc` or replacing `$COMPOSER_HOME` with `~/.composer/`.
+
+### Using PHAR file
+
+Please check the [releases](https://github.com/maglnet/ComposerRequireChecker/releases) for available phar files.
+ 
+### As dev project
+
+Composer require checker can also be installed in a separate directory via:
 
 ```sh
 composer create-project -s dev maglnet/composer-require-checker

--- a/bin/composer-require-checker.php
+++ b/bin/composer-require-checker.php
@@ -5,7 +5,26 @@ if (PHP_MAJOR_VERSION < 7) {
     exit(1);
 }
 
-require __DIR__ . '/../vendor/autoload.php';
+$autoloadFileLocations = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../../vendor/autoload.php',
+];
+
+$foundAutoloadFile = false;
+foreach ($autoloadFileLocations as $autoloadFileLocation) {
+    if (!file_exists($autoloadFileLocation)) {
+        continue;
+    }
+
+    $foundAutoloadFile = true;
+    require $autoloadFileLocation;
+    break;
+}
+
+if (false === $foundAutoloadFile) {
+    fprintf(STDERR, "Could not find Composer autoloader! Checked paths: %s\n", implode(', ', $autoloadFileLocations));
+    exit(2);
+}
 
 use ComposerRequireChecker\Cli\Application;
 

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
     "require-dev": {
         "phpunit/phpunit": "~5.0"
     },
+    "bin": [
+        "bin/composer-require-checker"
+    ],
     "autoload": {
         "psr-4": {
             "ComposerRequireChecker\\": "src/ComposerRequireChecker"

--- a/test/travis-composer.json
+++ b/test/travis-composer.json
@@ -1,0 +1,9 @@
+{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "TRAVIS_BUILD_DIR"
+        }
+    ],
+    "minimum-stability": "dev"
+}


### PR DESCRIPTION
It allows to install this package globally by `composer global require maglnet/composer-require-checker` and use the checker as any other command (if `$COMPOSER_HOME/vendor/bin` is added to `$PATH`).