### PR TITLE
Add missing symbols to whitelist

### DIFF
--- a/data/config.dist.json
+++ b/data/config.dist.json
@@ -2,7 +2,7 @@
   "symbol-whitelist" : [
     "null", "true", "false",
     "static", "self", "parent",
-    "array", "string", "int", "float", "bool", "iterable", "callable"
+    "array", "string", "int", "float", "bool", "iterable", "callable", "void"
   ],
   "php-core-extensions" : [
     "Core", "date", "pcre", "Reflection", "SPL", "standard"

--- a/data/config.dist.json
+++ b/data/config.dist.json
@@ -2,7 +2,7 @@
   "symbol-whitelist" : [
     "null", "true", "false",
     "static", "self", "parent",
-    "array", "string", "int", "float", "bool", "iterable"
+    "array", "string", "int", "float", "bool", "iterable", "callable"
   ],
   "php-core-extensions" : [
     "Core", "date", "pcre", "Reflection", "SPL", "standard"

--- a/data/config.dist.json
+++ b/data/config.dist.json
@@ -2,7 +2,7 @@
   "symbol-whitelist" : [
     "null", "true", "false",
     "static", "self", "parent",
-    "array", "string", "int", "float", "bool"
+    "array", "string", "int", "float", "bool", "iterable"
   ],
   "php-core-extensions" : [
     "Core", "date", "pcre", "Reflection", "SPL", "standard"

--- a/src/ComposerRequireChecker/Cli/Options.php
+++ b/src/ComposerRequireChecker/Cli/Options.php
@@ -8,7 +8,7 @@ class Options
     private $symbolWhitelist = [
         'null', 'true', 'false', // consts
         'static', 'self', 'parent', // class hierarchy
-        'array', 'string', 'int', 'float', 'bool' // types
+        'array', 'string', 'int', 'float', 'bool', 'iterable' // types
     ];
 
     private $phpCoreExtensions = [

--- a/src/ComposerRequireChecker/Cli/Options.php
+++ b/src/ComposerRequireChecker/Cli/Options.php
@@ -8,7 +8,7 @@ class Options
     private $symbolWhitelist = [
         'null', 'true', 'false', // consts
         'static', 'self', 'parent', // class hierarchy
-        'array', 'string', 'int', 'float', 'bool', 'iterable', 'callable' // types
+        'array', 'string', 'int', 'float', 'bool', 'iterable', 'callable', 'void' // types
     ];
 
     private $phpCoreExtensions = [

--- a/src/ComposerRequireChecker/Cli/Options.php
+++ b/src/ComposerRequireChecker/Cli/Options.php
@@ -8,7 +8,7 @@ class Options
     private $symbolWhitelist = [
         'null', 'true', 'false', // consts
         'static', 'self', 'parent', // class hierarchy
-        'array', 'string', 'int', 'float', 'bool', 'iterable' // types
+        'array', 'string', 'int', 'float', 'bool', 'iterable', 'callable' // types
     ];
 
     private $phpCoreExtensions = [


### PR DESCRIPTION
Adding `callable` and PHP 7.1's `iterable` and `void` types to whitelisted symbols.