### PR TITLE
Handle composer autoload directories as arrays correctly

### DIFF
--- a/src/ComposerRequireChecker/FileLocator/LocateComposerPackageSourceFiles.php
+++ b/src/ComposerRequireChecker/FileLocator/LocateComposerPackageSourceFiles.php
@@ -27,9 +27,13 @@ final class LocateComposerPackageSourceFiles
 
     private function getFilePaths(array $sourceDirs, string $packageDir) : array
     {
-        $flattened = array_reduce($sourceDirs, function(array $sourceDirs, $sourceDir) {
-            return $sourceDirs + (is_array($sourceDir) ? $sourceDir : [$sourceDir]);
-        }, []);
+        $flattened = array_reduce(
+            $sourceDirs,
+            function (array $sourceDirs, $sourceDir) {
+                return array_merge($sourceDirs, (array)$sourceDir);
+            },
+            []
+        );
         return array_values(array_map(
             function (string $sourceDir) use ($packageDir) {
                 return $packageDir . '/' . ltrim($sourceDir, '/');

--- a/src/ComposerRequireChecker/FileLocator/LocateComposerPackageSourceFiles.php
+++ b/src/ComposerRequireChecker/FileLocator/LocateComposerPackageSourceFiles.php
@@ -27,11 +27,14 @@ final class LocateComposerPackageSourceFiles
 
     private function getFilePaths(array $sourceDirs, string $packageDir) : array
     {
+        $flattened = array_reduce($sourceDirs, function(array $sourceDirs, $sourceDir) {
+            return $sourceDirs + (is_array($sourceDir) ? $sourceDir : [$sourceDir]);
+        }, []);
         return array_values(array_map(
             function (string $sourceDir) use ($packageDir) {
                 return $packageDir . '/' . ltrim($sourceDir, '/');
             },
-            $sourceDirs
+            $flattened
         ));
     }
 

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageSourceFilesTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageSourceFilesTest.php
@@ -118,7 +118,7 @@ class LocateComposerPackageSourceFilesTest extends TestCase
     /**
      * @return string[]
      */
-    private function files(string $composerJson)
+    private function files(string $composerJson): array
     {
         $files = [];
         $filesGenerator = ($this->locator)($composerJson);

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageSourceFilesTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageSourceFilesTest.php
@@ -85,6 +85,36 @@ class LocateComposerPackageSourceFilesTest extends TestCase
         $this->assertCount(1, $files);
     }
 
+    public function testFromPsr0WithMultipleDirectories()
+    {
+        vfsStream::create([
+            'composer.json' => '{"autoload": {"psr-0": {"MyNamespace\\\\": ["src", "lib"]}}}',
+            'src' => ['MyNamespace' => ['MyClassA.php' => '<?php namespace MyNamespace; class MyClassA {}']],
+            'lib' => ['MyNamespace' => ['MyClassB.php' => '<?php namespace MyNamespace; class MyClassB {}']],
+        ]);
+
+        $files = $this->files($this->root->getChild('composer.json')->url());
+
+        $this->assertCount(2, $files);
+        $this->assertContains($this->root->getChild('src/MyClassA.php')->url(), $files);
+        $this->assertContains($this->root->getChild('lib/MyClassB.php')->url(), $files);
+    }
+
+    public function testFromPsr4WithMultipleDirectories()
+    {
+        vfsStream::create([
+            'composer.json' => '{"autoload": {"psr-4": {"MyNamespace\\\\": ["src", "lib"]}}}',
+            'src' => ['MyClassA.php' => '<?php namespace MyNamespace; class MyClassA {}'],
+            'lib' => ['MyClassB.php' => '<?php namespace MyNamespace; class MyClassB {}'],
+        ]);
+
+        $files = $this->files($this->root->getChild('composer.json')->url());
+
+        $this->assertCount(2, $files);
+        $this->assertContains($this->root->getChild('src/MyClassA.php')->url(), $files);
+        $this->assertContains($this->root->getChild('lib/MyClassB.php')->url(), $files);
+    }
+
     /**
      * @return string[]
      */

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageSourceFilesTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageSourceFilesTest.php
@@ -96,8 +96,8 @@ class LocateComposerPackageSourceFilesTest extends TestCase
         $files = $this->files($this->root->getChild('composer.json')->url());
 
         $this->assertCount(2, $files);
-        $this->assertContains($this->root->getChild('src/MyClassA.php')->url(), $files);
-        $this->assertContains($this->root->getChild('lib/MyClassB.php')->url(), $files);
+        $this->assertContains($this->root->getChild('src/MyNamespace/MyClassA.php')->url(), $files);
+        $this->assertContains($this->root->getChild('lib/MyNamespace/MyClassB.php')->url(), $files);
     }
 
     public function testFromPsr4WithMultipleDirectories()
@@ -120,6 +120,11 @@ class LocateComposerPackageSourceFilesTest extends TestCase
      */
     private function files(string $composerJson)
     {
-        return iterator_to_array(($this->locator)($composerJson));
+        $files = [];
+        $filesGenerator = ($this->locator)($composerJson);
+        foreach ($filesGenerator as $file) {
+            $files[] = $file;
+        }
+        return $files;
     }
 }


### PR DESCRIPTION
The `{"autoload": {"psr-0|psr-4": {"MyNamespace": ["src", "lib"]}}}` format doesn't work at the moment.

This tries to fix that, but the tests are still failing at the moment and I can't figure out why.

Also, I'm not sure if the `array_reduce()` method is the clearest way to write this, but I tried to follow the functional style of the existing code.

Can someone figure out what's wrong?