### PR TITLE
write the count of found symbols for manual sanity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- print the count of found symbols for a manual sanity check
 
 ### Changed
 

--- a/src/ComposerRequireChecker/Cli/CheckCommand.php
+++ b/src/ComposerRequireChecker/Cli/CheckCommand.php
@@ -88,6 +88,8 @@ class CheckCommand extends Command
             $options->getSymbolWhitelist()
         );
 
+        $output->writeln("Symbols checked: " . count($usedSymbols));
+
         if (!$unknownSymbols) {
             $output->writeln("There were no unknown symbols found.");
             return 0;


### PR DESCRIPTION
Possibility to manually do a sanity check, if symbols have been found. This idea comes from #25 

The output now looks like this:
```bash
$ php bin/composer-require-checker
ComposerRequireChecker 0.1.4-4-g399b1a5-dev
Symbols checked: 101
There were no unknown symbols found.

```