### PR TITLE
Fix exclude-from-classpath containing wildcards

### DIFF
--- a/src/ComposerRequireChecker/FileLocator/LocateAllFilesByExtension.php
+++ b/src/ComposerRequireChecker/FileLocator/LocateAllFilesByExtension.php
@@ -24,6 +24,8 @@ final class LocateAllFilesByExtension
     {
         $extensionMatcher = '/.*' . preg_quote($fileExtension) . '$/';
 
+        $blacklist = $this->prepareBlacklistPatterns($blacklist);
+
         /* @var $file \SplFileInfo */
         foreach ($files as $file) {
             if ($blacklist && preg_match('{('.implode('|', $blacklist).')}', $file->getPathname())) {
@@ -36,5 +38,20 @@ final class LocateAllFilesByExtension
 
             yield $file->getPathname();
         }
+    }
+
+    private function prepareBlacklistPatterns(?array $blacklistPaths)
+    {
+        if ($blacklistPaths === null) {
+            return $blacklistPaths;
+        }
+
+        foreach ($blacklistPaths as &$path) {
+            $path = preg_replace('{/+}', '/', preg_quote(trim(strtr($path, '\\', '/'), '/')));
+            $path = str_replace('\\*\\*', '.+?', $path);
+            $path = str_replace('\\*', '[^/]+?', $path);
+        }
+
+        return $blacklistPaths;
     }
 }


### PR DESCRIPTION
Hi and thanks for this great tool! 

With the latest version (which adds exclude-from-classpath support), I observed an common errors like this:
```
Warning: preg_match(): Compilation failed: nothing to repeat at offset 1 in phar:///.../composer-require-checker.phar/src/ComposerRequireChecker/FileLocator/LocateAllFilesByExtension.php on line 29
```

This is because `exclude-from-classpath` [can](https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps) contain `*` and `**` wildcards. For example in Symfony: https://github.com/symfony/symfony/blob/master/composer.json#L125 .

These `*` and `**` sequences obviously breaks the regexp pattern used in LocateAllFilesByExtension.php and causes the mentioned error.

This PR adds regexp escaping and also supports of the actual wildcards behavior, as per Composer source code: https://github.com/composer/composer/blob/be040f8e3111b38c1e49ae5cd6b929dbf5c39045/src/Composer/Autoload/AutoloadGenerator.php#L848-L854
