### PR TITLE
adding option to manually register psr0/psr4-like dependency autoloading

### DIFF
--- a/src/ComposerRequireChecker/Cli/CheckCommand.php
+++ b/src/ComposerRequireChecker/Cli/CheckCommand.php
@@ -40,12 +40,18 @@ class CheckCommand extends Command
                 'the composer.json of your package, that should be checked',
                 './composer.json'
             )
-        ->addOption(
+            ->addOption(
                 'ignore-parse-errors',
                 null,
                 InputOption::VALUE_NONE,
                 'this will cause ComposerRequireChecker to ignore errors when files cannot be parsed, otherwise'
                 . ' errors will be thrown'
+            )
+            ->addOption(
+                'register-namespace',
+                null,
+                InputOption::VALUE_IS_ARRAY|InputOption::VALUE_OPTIONAL,
+                'vendor/package:namespace:path as if it was psr4'
             );
     }
 
@@ -64,13 +70,14 @@ class CheckCommand extends Command
         $options = $this->getCheckOptions($input);
 
         $getPackageSourceFiles = new LocateComposerPackageSourceFiles();
+        $manualRegistered = $this->buildManualList($input, $composerJson);
 
         $sourcesASTs = $this->getASTFromFilesLocator($input);
 
         $definedVendorSymbols = (new LocateDefinedSymbolsFromASTRoots())->__invoke($sourcesASTs(
             (new ComposeGenerators())->__invoke(
                 $getPackageSourceFiles($composerJson),
-                (new LocateComposerPackageDirectDependenciesSourceFiles())->__invoke($composerJson)
+                (new LocateComposerPackageDirectDependenciesSourceFiles())->__invoke($composerJson, $manualRegistered)
             )
         ));
 
@@ -145,4 +152,21 @@ class CheckCommand extends Command
         return $sourcesASTs;
     }
 
+    /**
+     * @return array
+     */
+    private function buildManualList(InputInterface $input, $composerJson)
+    {
+        if(!$input->hasOption('register-namespace')) {
+            return [];
+        }
+        $packageDir = dirname($composerJson);
+        $namespaces = [];
+        foreach($input->getOption('register-namespace') as $option) {
+            if(preg_match('!^([^/:]+(/[^/:]+)+):([^:]+):([^:]+)$!i', $option, $matches)) {
+                $namespaces[$packageDir . '/vendor/' . $matches[1]][$matches[3]] = $matches[4];
+            }
+        }
+        return $namespaces;
+    }
 }

--- a/src/ComposerRequireChecker/FileLocator/LocateComposerPackageDirectDependenciesSourceFiles.php
+++ b/src/ComposerRequireChecker/FileLocator/LocateComposerPackageDirectDependenciesSourceFiles.php
@@ -6,7 +6,7 @@ use Generator;
 
 final class LocateComposerPackageDirectDependenciesSourceFiles
 {
-    public function __invoke(string $composerJsonPath): Generator
+    public function __invoke(string $composerJsonPath, array $manual = []): Generator
     {
         $packageDir = dirname($composerJsonPath);
 
@@ -22,7 +22,10 @@ final class LocateComposerPackageDirectDependenciesSourceFiles
                 continue;
             }
 
-            yield from (new LocateComposerPackageSourceFiles())->__invoke($vendorDir . '/composer.json');
+            yield from (new LocateComposerPackageSourceFiles())->__invoke(
+                $vendorDir . '/composer.json',
+                $manual[$vendorDir] ?? []
+            );
         }
     }
 }

--- a/src/ComposerRequireChecker/FileLocator/LocateComposerPackageSourceFiles.php
+++ b/src/ComposerRequireChecker/FileLocator/LocateComposerPackageSourceFiles.php
@@ -6,7 +6,7 @@ use Generator;
 
 final class LocateComposerPackageSourceFiles
 {
-    public function __invoke(string $composerJsonPath): Generator
+    public function __invoke(string $composerJsonPath, array $manual = []): Generator
     {
         $packageDir = dirname($composerJsonPath);
         $composerData = json_decode(file_get_contents($composerJsonPath), true);
@@ -27,6 +27,10 @@ final class LocateComposerPackageSourceFiles
         );
         yield from $this->locateFilesInPsr4Definitions(
             $this->getFilePaths($composerData['autoload']['psr-4'] ?? [], $packageDir),
+            $blacklist
+        );
+        yield from $this->locateFilesInFilesInFilesDefinitions(
+            $this->getFilePaths($manual, $packageDir),
             $blacklist
         );
     }


### PR DESCRIPTION
I did stumble upon older versions of libraries(nikic's php-parser in this case), where there is an autoloader of it's own.
This option is meant to help deal with that issue by adding a psr4-like autoloading-definition to packages. It does not change the default behaviour, but might be a workaround for some of #55's issues.