### PR TITLE
Add support for appending config options

### DIFF
--- a/test/ComposerRequireCheckerTest/Cli/OptionsTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/OptionsTest.php
@@ -22,6 +22,18 @@ class OptionsTest extends TestCase
         $this->assertSame(['something'], $options->getPhpCoreExtensions());
     }
 
+    public function testOptionsAppendPhpCoreExtensions()
+    {
+        $options = new Options([
+            'append' => [
+                'php-core-extensions' => ['something']
+            ],
+        ]);
+
+        $this->assertContains('something', $options->getPhpCoreExtensions());
+        $this->assertContains('Reflection', $options->getPhpCoreExtensions());
+    }
+
     public function testOptionsAcceptSymbolWhitelist()
     {
         $options = new Options([
@@ -29,6 +41,19 @@ class OptionsTest extends TestCase
         ]);
 
         $this->assertSame(['foo', 'bar'], $options->getSymbolWhitelist());
+    }
+
+    public function testOptionsAppendSymbolWhitelist()
+    {
+        $options = new Options([
+            'append' => [
+                'symbol-whitelist' => ['foo', 'bar'],
+            ],
+        ]);
+
+        $this->assertContains('foo', $options->getSymbolWhitelist());
+        $this->assertContains('bar', $options->getSymbolWhitelist());
+        $this->assertContains('null', $options->getSymbolWhitelist());
     }
 
     public function testOptionsFileRepresentsDefaults()


### PR DESCRIPTION
When configuring to exclude a symbol, we have to copy all the default symbols, and then keep that up to date as new symbols are added in future.

To avoid this, I propose allowing configuration to be appended to, as well as overwritten:
```json
{
  "append": {
    "symbol-whitelist" : ["strict"],
    "php-core-extensions" : ["json"]
  }
}
```