### PR TITLE
Prevent using symfony/console with broken exit code handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ext-json":         "*",
         "ext-phar":         "*",
         "nikic/php-parser": "^4.0",
-        "symfony/console":  "^3.0 || ^4.0",
+        "symfony/console":  "^3.4.17 | ^4.1.6",
         "webmozart/glob":   "^4.1"
     },
     "require-dev": {


### PR DESCRIPTION
There's a [bug](https://github.com/symfony/symfony/issues/28666) in symfony/console 3.4.16 and 4.1.5 where the exit code is reported as success if it failed.

This obviously affects this tool in a major way rendering it useless in a CI environment, so this PR ensures this bug cannot be installed.

