### PR TITLE
Fix handling files found with "scan-files" option

### DIFF
--- a/src/ComposerRequireChecker/Cli/CheckCommand.php
+++ b/src/ComposerRequireChecker/Cli/CheckCommand.php
@@ -86,12 +86,12 @@ class CheckCommand extends Command
         $this->verbose("found " . count($definedExtensionSymbols) . " symbols.", $output, true);
 
         $this->verbose("Collecting used symbols... ", $output);
-        $usedSymbols = (new LocateUsedSymbolsFromASTRoots())->__invoke(
+        $usedSymbols = (new LocateUsedSymbolsFromASTRoots())->__invoke($sourcesASTs(
             (new ComposeGenerators())->__invoke(
-                $sourcesASTs($getPackageSourceFiles($composerJson)),
+                $getPackageSourceFiles($composerJson),
                 $getAdditionalSourceFiles($options->getScanFiles(), dirname($composerJson))
             )
-        );
+        ));
         $this->verbose("found " . count($usedSymbols) . " symbols.", $output, true);
 
         if (!count($usedSymbols)) {


### PR DESCRIPTION
Using the `scan-files` option in the config file leads to the following error:
```
TypeError: Argument 1 passed to PhpParser\NodeTraverser::traverse() must be of the type array, string given, called in src/ComposerRequireChecker/UsedSymbolsLocator/LocateUsedSymbolsFromASTRoots.php on line 28

vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:82
src/ComposerRequireChecker/UsedSymbolsLocator/LocateUsedSymbolsFromASTRoots.php:28
src/ComposerRequireChecker/Cli/CheckCommand.php:92
vendor/symfony/console/Command/Command.php:255
vendor/symfony/console/Tester/CommandTester.php:77
test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php:80
```