### PR TITLE
Enhancement: Add void return type declarations to test methods

### DIFF
--- a/test/ComposerRequireCheckerTest/ASTLocator/LocateASTFromFilesTest.php
+++ b/test/ComposerRequireCheckerTest/ASTLocator/LocateASTFromFilesTest.php
@@ -22,7 +22,7 @@ class LocateASTFromFilesTest extends TestCase
     /** @var vfsStreamDirectory */
     private $root;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -30,7 +30,7 @@ class LocateASTFromFilesTest extends TestCase
         $this->root = vfsStream::setup();
     }
 
-    public function testLocate()
+    public function testLocate(): void
     {
         $files = [
             $this->createFile('MyClassA', '<?php class MyClassA {}'),
@@ -42,7 +42,7 @@ class LocateASTFromFilesTest extends TestCase
         $this->assertCount(2, $roots);
     }
 
-    public function testFailOnParseError()
+    public function testFailOnParseError(): void
     {
         $this->expectException(Error::class);
         $files = [
@@ -52,7 +52,7 @@ class LocateASTFromFilesTest extends TestCase
         $this->locate($files);
     }
 
-    public function testDoNotFailOnParseErrorWithErrorHandler()
+    public function testDoNotFailOnParseErrorWithErrorHandler(): void
     {
         $collectingErrorHandler = new Collecting();
         $this->locator = new LocateASTFromFiles(new Php7(new Lexer()), $collectingErrorHandler);

--- a/test/ComposerRequireCheckerTest/BinaryTest.php
+++ b/test/ComposerRequireCheckerTest/BinaryTest.php
@@ -15,13 +15,13 @@ class BinaryTest extends TestCase
         $this->bin = __DIR__ . "/../../bin/composer-require-checker";
     }
 
-    public function testSuccess()
+    public function testSuccess(): void
     {
         exec($this->bin, $output, $return);
         $this->assertSame(0, $return);
     }
 
-    public function testUnknownSymbols()
+    public function testUnknownSymbols(): void
     {
         $path = __DIR__ . "/../fixtures/unknownSymbols/composer.json";
         exec("{$this->bin} check {$path} 2>&1", $output, $return);
@@ -29,7 +29,7 @@ class BinaryTest extends TestCase
         $this->assertContains("The following unknown symbols were found", implode("\n", $output));
     }
 
-    public function testInvalidConfiguration()
+    public function testInvalidConfiguration(): void
     {
         $path = __DIR__ . "/../fixtures/validJson.json";
         exec("{$this->bin} check {$path} 2>&1", $output, $return);

--- a/test/ComposerRequireCheckerTest/Cli/ApplicationTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/ApplicationTest.php
@@ -14,12 +14,12 @@ class ApplicationTest extends TestCase
      */
     private $application;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->application = new Application();
     }
 
-    public function testCheckCommandExists()
+    public function testCheckCommandExists(): void
     {
         $this->assertTrue($this->application->has('check'));
         $this->assertInstanceOf(Command::class, $this->application->get('check'));

--- a/test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php
@@ -16,7 +16,7 @@ class CheckCommandTest extends TestCase
      */
     private $commandTester;
 
-    public function setUp()
+    public function setUp(): void
     {
         $application = new Application();
         $command = $application->get('check');
@@ -24,7 +24,7 @@ class CheckCommandTest extends TestCase
         $this->commandTester = new CommandTester($command);
     }
 
-    public function testExceptionIfComposerJsonNotFound()
+    public function testExceptionIfComposerJsonNotFound(): void
     {
         self::expectException(\InvalidArgumentException::class);
 
@@ -33,7 +33,7 @@ class CheckCommandTest extends TestCase
         ]);
     }
 
-    public function testSelfCheckShowsNoErrors()
+    public function testSelfCheckShowsNoErrors(): void
     {
         $this->commandTester->execute([
             // that's our own composer.json, lets be sure our self check does not throw errors
@@ -48,7 +48,7 @@ class CheckCommandTest extends TestCase
         $this->assertNotRegExp('/Collecting used symbols... found \d+ symbols./', $this->commandTester->getDisplay());
     }
 
-    public function testVerboseSelfCheckShowsCounts()
+    public function testVerboseSelfCheckShowsCounts(): void
     {
         $this->commandTester->execute([
             // that's our own composer.json
@@ -62,7 +62,7 @@ class CheckCommandTest extends TestCase
         $this->assertRegExp('/Collecting used symbols... found \d+ symbols./', $this->commandTester->getDisplay());
     }
 
-    public function testWithAdditionalSourceFiles()
+    public function testWithAdditionalSourceFiles(): void
     {
         $root = vfsStream::setup();
         vfsStream::create([

--- a/test/ComposerRequireCheckerTest/Cli/OptionsTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/OptionsTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class OptionsTest extends TestCase
 {
-    public function testOptionsAcceptPhpCoreExtensions()
+    public function testOptionsAcceptPhpCoreExtensions(): void
     {
         $options = new Options([
             'php-core-extensions' => ['something']
@@ -22,7 +22,7 @@ class OptionsTest extends TestCase
         $this->assertSame(['something'], $options->getPhpCoreExtensions());
     }
 
-    public function testOptionsAcceptSymbolWhitelist()
+    public function testOptionsAcceptSymbolWhitelist(): void
     {
         $options = new Options([
             'symbol-whitelist' => ['foo', 'bar']
@@ -31,7 +31,7 @@ class OptionsTest extends TestCase
         $this->assertSame(['foo', 'bar'], $options->getSymbolWhitelist());
     }
 
-    public function testOptionsFileRepresentsDefaults()
+    public function testOptionsFileRepresentsDefaults(): void
     {
         $options = new Options();
 
@@ -44,7 +44,7 @@ class OptionsTest extends TestCase
         $this->assertEquals($options, $optionsFromFile);
     }
 
-    public function testThrowsExceptionForUnknownOptions()
+    public function testThrowsExceptionForUnknownOptions(): void
     {
         $this->expectException('InvalidArgumentException');
         $options = new Options([

--- a/test/ComposerRequireCheckerTest/DefinedExtensionsResolver/DefinedExtensionsResolverTest.php
+++ b/test/ComposerRequireCheckerTest/DefinedExtensionsResolver/DefinedExtensionsResolverTest.php
@@ -17,7 +17,7 @@ class DefinedExtensionsResolverTest extends TestCase
     /** @var vfsStreamDirectory */
     private $root;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -25,7 +25,7 @@ class DefinedExtensionsResolverTest extends TestCase
         $this->root = vfsStream::setup();
     }
 
-    public function testNoExtensions()
+    public function testNoExtensions(): void
     {
         $composerJson = vfsStream::newFile('composer.json')->at($this->root)->setContent('{}')->url();
 
@@ -34,7 +34,7 @@ class DefinedExtensionsResolverTest extends TestCase
         $this->assertCount(0, $extensions);
     }
 
-    public function testCoreExtensions()
+    public function testCoreExtensions(): void
     {
         $composerJson = vfsStream::newFile('composer.json')->at($this->root)
             ->setContent('{"require":{"php":"^7.0"}}')
@@ -46,7 +46,7 @@ class DefinedExtensionsResolverTest extends TestCase
         $this->assertSame('*', reset($extensions));
     }
 
-    public function testCoreExtensionsIn64Bit()
+    public function testCoreExtensionsIn64Bit(): void
     {
         $composerJson = vfsStream::newFile('composer.json')->at($this->root)
             ->setContent('{"require":{"php-64bit":"^7.0"}}')
@@ -58,7 +58,7 @@ class DefinedExtensionsResolverTest extends TestCase
         $this->assertSame('*', reset($extensions));
     }
 
-    public function testExtensionsAreReturned()
+    public function testExtensionsAreReturned(): void
     {
         $composerJson = vfsStream::newFile('composer.json')->at($this->root)
             ->setContent('{"require":{"ext-zip":"*","ext-curl":"*"}}')

--- a/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromASTRootsTest.php
+++ b/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromASTRootsTest.php
@@ -21,21 +21,21 @@ class LocateDefinedSymbolsFromASTRootsTest extends TestCase
     /** @var LocateDefinedSymbolsFromASTRoots */
     private $locator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->locator = new LocateDefinedSymbolsFromASTRoots();
     }
 
-    public function testNoRoots()
+    public function testNoRoots(): void
     {
         $symbols = $this->locate([]);
 
         $this->assertCount(0, $symbols);
     }
 
-    public function testBasicLocateClass()
+    public function testBasicLocateClass(): void
     {
         $roots = [
             new Class_('MyClassA'), new Class_('MyClassB'),
@@ -52,7 +52,7 @@ class LocateDefinedSymbolsFromASTRootsTest extends TestCase
         $this->assertContains('MyClassC', $symbols);
     }
 
-    public function testBasicLocateFunctions()
+    public function testBasicLocateFunctions(): void
     {
         $roots = [
             new Function_('myFunctionA'),
@@ -68,7 +68,7 @@ class LocateDefinedSymbolsFromASTRootsTest extends TestCase
         $this->assertContains('myFunctionB', $symbols);
     }
 
-    public function testBasicLocateTrait()
+    public function testBasicLocateTrait(): void
     {
         $roots = [
             new Trait_('MyTraitA'), new Trait_('MyTraitB'),
@@ -85,7 +85,7 @@ class LocateDefinedSymbolsFromASTRootsTest extends TestCase
         $this->assertContains('MyTraitC', $symbols);
     }
 
-    public function testBasicLocateAnonymous()
+    public function testBasicLocateAnonymous(): void
     {
         $roots = [
             new Class_(null),
@@ -97,7 +97,7 @@ class LocateDefinedSymbolsFromASTRootsTest extends TestCase
         $this->assertCount(0, $symbols);
     }
 
-    public function testBasicLocateDefineCalls()
+    public function testBasicLocateDefineCalls(): void
     {
         $roots = [
             new FuncCall(new Name('define'), [
@@ -113,7 +113,7 @@ class LocateDefinedSymbolsFromASTRootsTest extends TestCase
 
     }
 
-    public function testBasicDoNotLocateNamespacedDefineCalls()
+    public function testBasicDoNotLocateNamespacedDefineCalls(): void
     {
         $roots = [
             new FuncCall(new Name('define', ['namespacedName' => new Name\FullyQualified('Foo\define')]), [

--- a/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromExtensionsTest.php
+++ b/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromExtensionsTest.php
@@ -16,50 +16,50 @@ class LocateDefinedSymbolsFromExtensionsTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->locator = new LocateDefinedSymbolsFromExtensions();
     }
 
-    public function testThrowsExceptionForUnknownExtension()
+    public function testThrowsExceptionForUnknownExtension(): void
     {
         $this->expectException('ComposerRequireChecker\Exception\UnknownExtensionException');
         $this->locator->__invoke(['unknown_extension_name']);
     }
 
-    public function testReturnsFilledArray()
+    public function testReturnsFilledArray(): void
     {
         $symbols = $this->locator->__invoke(['Core']);
         $this->assertGreaterThan(1, count($symbols));
         $this->assertInternalType('array', $symbols);
     }
 
-    public function testSymbolsContainConstants()
+    public function testSymbolsContainConstants(): void
     {
         $symbols = $this->locator->__invoke(['Core']);
         $this->assertTrue(in_array('PHP_VERSION', $symbols));
     }
 
-    public function testSymbolsContainFunctions()
+    public function testSymbolsContainFunctions(): void
     {
         $symbols = $this->locator->__invoke(['Core']);
         $this->assertTrue(in_array('strlen', $symbols));
     }
 
-    public function testSymbolsContainClasses()
+    public function testSymbolsContainClasses(): void
     {
         $symbols = $this->locator->__invoke(['Core']);
         $this->assertTrue(in_array('stdClass', $symbols));
     }
 
-    public function testPackageNameInterpolation()
+    public function testPackageNameInterpolation(): void
     {
         $symbols = $this->locator->__invoke(['zend-opcache']);
         $symbols2 = $this->locator->__invoke(['Zend Opcache']);
         $this->assertEquals($symbols, $symbols2);
     }
 
-    public function testCanHandleMultipleExtensions()
+    public function testCanHandleMultipleExtensions(): void
     {
         $coreSymbols = $this->locator->__invoke(['Core']);
         $standardSymbols = $this->locator->__invoke(['standard']);

--- a/test/ComposerRequireCheckerTest/DependencyGuesser/DependencyGuesserTest.php
+++ b/test/ComposerRequireCheckerTest/DependencyGuesser/DependencyGuesserTest.php
@@ -14,12 +14,12 @@ class DependencyGuesserTest extends TestCase
      */
     private $guesser;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->guesser = new DependencyGuesser();
     }
 
-    public function testGuessExtJson()
+    public function testGuessExtJson(): void
     {
         if (!extension_loaded('json')) {
             $this->markTestSkipped('extension json is not available');
@@ -29,13 +29,13 @@ class DependencyGuesserTest extends TestCase
         $this->assertContains('ext-json', $result);
     }
 
-    public function testDoesNotSuggestAnything()
+    public function testDoesNotSuggestAnything(): void
     {
         $result = $this->guesser->__invoke('an_hopefully_unique_unknown_symbol');
         $this->assertFalse($result->valid());
     }
 
-    public function testCoreExtensionsResolvesToPHP()
+    public function testCoreExtensionsResolvesToPHP(): void
     {
         $options = new Options(['php-core-extensions' => ['SPL', 'something-else']]);
         $this->guesser = new DependencyGuesser($options);

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateAllFilesByExtensionTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateAllFilesByExtensionTest.php
@@ -18,7 +18,7 @@ class LocateAllFilesByExtensionTest extends TestCase
     /** @var vfsStreamDirectory */
     private $root;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -26,14 +26,14 @@ class LocateAllFilesByExtensionTest extends TestCase
         $this->root = vfsStream::setup();
     }
 
-    public function testLocateFromNoDirectories()
+    public function testLocateFromNoDirectories(): void
     {
         $files = $this->locate([], '.php', null);
 
         $this->assertCount(0, $files);
     }
 
-    public function testLocateFromASingleDirectory()
+    public function testLocateFromASingleDirectory(): void
     {
         $dir = vfsStream::newDirectory('MyNamespaceA')->at($this->root);
         $files = [];

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageDirectDependenciesSourceFilesTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageDirectDependenciesSourceFilesTest.php
@@ -17,7 +17,7 @@ class LocateComposerPackageDirectDependenciesSourceFilesTest extends TestCase
     /** @var vfsStreamDirectory */
     private $root;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -25,7 +25,7 @@ class LocateComposerPackageDirectDependenciesSourceFilesTest extends TestCase
         $this->root = vfsStream::setup();
     }
 
-    public function testNoDependencies()
+    public function testNoDependencies(): void
     {
         vfsStream::create([
             'composer.json' => '{}',
@@ -41,7 +41,7 @@ class LocateComposerPackageDirectDependenciesSourceFilesTest extends TestCase
         $this->assertCount(0, $files);
     }
 
-    public function testSingleDependency()
+    public function testSingleDependency(): void
     {
         vfsStream::create([
             'composer.json' => '{"require":{"foo/bar": "^1.0"}}',
@@ -68,7 +68,7 @@ class LocateComposerPackageDirectDependenciesSourceFilesTest extends TestCase
         $this->assertSame($expectedFile, $actualFile);
     }
 
-    public function testVendorDirsWithoutComposerFilesAreIgnored()
+    public function testVendorDirsWithoutComposerFilesAreIgnored(): void
     {
         vfsStream::create([
             'composer.json' => '{"require": {"foo/bar": "^1.0"}}',
@@ -91,7 +91,7 @@ class LocateComposerPackageDirectDependenciesSourceFilesTest extends TestCase
         $this->assertCount(0, $files);
     }
 
-    public function testVendorConfigSettingIsBeingUsed()
+    public function testVendorConfigSettingIsBeingUsed(): void
     {
         vfsStream::create([
             'composer.json' => '{"require":{"foo/bar": "^1.0"},"config":{"vendor-dir":"alternate-vendor"}}',
@@ -118,7 +118,7 @@ class LocateComposerPackageDirectDependenciesSourceFilesTest extends TestCase
         $this->assertSame($expectedFile, $actualFile);
     }
 
-    public function testInstalledJsonUsedAsFallback()
+    public function testInstalledJsonUsedAsFallback(): void
     {
         vfsStream::create([
             'composer.json' => '{"require":{"foo/bar": "^1.0"}}',
@@ -152,7 +152,7 @@ class LocateComposerPackageDirectDependenciesSourceFilesTest extends TestCase
     /**
      * https://github.com/composer/composer/pull/7999
      */
-    public function testOldInstalledJsonUsedAsFallback()
+    public function testOldInstalledJsonUsedAsFallback(): void
     {
         vfsStream::create([
             'composer.json' => '{"require":{"foo/bar": "^1.0"}}',

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageSourceFilesTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageSourceFilesTest.php
@@ -18,7 +18,7 @@ class LocateComposerPackageSourceFilesTest extends TestCase
     /** @var vfsStreamDirectory */
     private $root;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -26,7 +26,7 @@ class LocateComposerPackageSourceFilesTest extends TestCase
         $this->root = vfsStream::setup();
     }
 
-    public function testFromClassmap()
+    public function testFromClassmap(): void
     {
         vfsStream::create([
             'composer.json' => '{"autoload": {"classmap": ["src/MyClassA.php", "MyClassB.php"]}}',
@@ -43,7 +43,7 @@ class LocateComposerPackageSourceFilesTest extends TestCase
         $this->assertContains($this->root->getChild('MyClassB.php')->url(), $files);
     }
 
-    public function testFromFiles()
+    public function testFromFiles(): void
     {
         vfsStream::create([
             'composer.json' => '{"autoload": {"files": ["foo.php"]}}',
@@ -56,7 +56,7 @@ class LocateComposerPackageSourceFilesTest extends TestCase
         $this->assertContains($this->root->getChild('foo.php')->url(), $files);
     }
 
-    public function testFromPsr0()
+    public function testFromPsr0(): void
     {
         vfsStream::create([
             'composer.json' => '{"autoload": {"psr-0": ["src"]}}',
@@ -72,7 +72,7 @@ class LocateComposerPackageSourceFilesTest extends TestCase
         $this->assertCount(1, $files);
     }
 
-    public function testFromPsr4()
+    public function testFromPsr4(): void
     {
         vfsStream::create([
             'composer.json' => '{"autoload": {"psr-4": {"MyNamespace\\\\": "src"}}}',
@@ -86,7 +86,7 @@ class LocateComposerPackageSourceFilesTest extends TestCase
         $this->assertCount(1, $files);
     }
 
-    public function testFromPsr0WithMultipleDirectories()
+    public function testFromPsr0WithMultipleDirectories(): void
     {
         vfsStream::create([
             'composer.json' => '{"autoload": {"psr-0": {"MyNamespace\\\\": ["src", "lib"]}}}',
@@ -101,7 +101,7 @@ class LocateComposerPackageSourceFilesTest extends TestCase
         $this->assertContains($this->root->getChild('lib/MyNamespace/MyClassB.php')->url(), $files);
     }
 
-    public function testFromPsr4WithMultipleDirectories()
+    public function testFromPsr4WithMultipleDirectories(): void
     {
         vfsStream::create([
             'composer.json' => '{"autoload": {"psr-4": {"MyNamespace\\\\": ["src", "lib"]}}}',
@@ -116,7 +116,7 @@ class LocateComposerPackageSourceFilesTest extends TestCase
         $this->assertContains($this->root->getChild('lib/MyClassB.php')->url(), $files);
     }
 
-    public function testFromPsr4WithNestedDirectory()
+    public function testFromPsr4WithNestedDirectory(): void
     {
         vfsStream::create([
             'composer.json' => '{"autoload": {"psr-4": {"MyNamespace\\\\": ["src/MyNamespace"]}}}',
@@ -131,7 +131,7 @@ class LocateComposerPackageSourceFilesTest extends TestCase
         $this->assertContains($this->root->getChild('src/MyNamespace/MyClassA.php')->url(), $files);
     }
 
-    public function testFromPsr4WithNestedDirectoryAlternativeDirectorySeparator()
+    public function testFromPsr4WithNestedDirectoryAlternativeDirectorySeparator(): void
     {
         vfsStream::create([
             'composer.json' => '{"autoload": {"psr-4": {"MyNamespace\\\\": ["src\\\\MyNamespace"]}}}',
@@ -149,7 +149,7 @@ class LocateComposerPackageSourceFilesTest extends TestCase
     /**
      * @dataProvider provideExcludePattern
      */
-    public function testFromPsr4WithExcludeFromClassmap(array $excludedPattern, array $expectedFiles)
+    public function testFromPsr4WithExcludeFromClassmap(array $excludedPattern, array $expectedFiles): void
     {
         $excludedPatternJson = json_encode($excludedPattern);
 

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateFilesByGlobPatternTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateFilesByGlobPatternTest.php
@@ -21,13 +21,13 @@ class LocateFilesByGlobPatternTest extends TestCase
      */
     private $root;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->locator = new LocateFilesByGlobPattern();
         $this->root = vfsStream::setup();
     }
 
-    public function testSimpleGlobPattern()
+    public function testSimpleGlobPattern(): void
     {
         vfsStream::create([
             'bin' => [
@@ -41,7 +41,7 @@ class LocateFilesByGlobPatternTest extends TestCase
         self::assertContains($this->root->getChild('bin/console')->url(), $files);
     }
 
-    public function testGlobPattern()
+    public function testGlobPattern(): void
     {
         vfsStream::create([
             'bin' => [

--- a/test/ComposerRequireCheckerTest/JsonLoaderTest.php
+++ b/test/ComposerRequireCheckerTest/JsonLoaderTest.php
@@ -12,21 +12,21 @@ use PHPUnit\Framework\TestCase;
  */
 class JsonLoaderTest extends TestCase
 {
-    public function testHasErrorWithWrongPath()
+    public function testHasErrorWithWrongPath(): void
     {
         $path = __DIR__ . '/wrong/path/non-existing-file.json';
         $this->expectException(NotReadableException::class);
         new JsonLoader($path);
     }
 
-    public function testHasErrorWithInvalidFile()
+    public function testHasErrorWithInvalidFile(): void
     {
         $path = __DIR__ . '/../fixtures/invalidJson';
         $this->expectException(InvalidJsonException::class);
         new JsonLoader($path);
     }
 
-    public function testHasDataWithValidFile()
+    public function testHasDataWithValidFile(): void
     {
         $path = __DIR__ . '/../fixtures/validJson.json';
         $loader = new JsonLoader($path);

--- a/test/ComposerRequireCheckerTest/NodeVisitor/DefinedSymbolCollectorFunctionalTest.php
+++ b/test/ComposerRequireCheckerTest/NodeVisitor/DefinedSymbolCollectorFunctionalTest.php
@@ -35,7 +35,7 @@ final class DefinedSymbolCollectorFunctionalTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->collector = new DefinedSymbolCollector();
         $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
@@ -45,7 +45,7 @@ final class DefinedSymbolCollectorFunctionalTest extends TestCase
         $this->traverser->addVisitor($this->collector);
     }
 
-    public function testWillCollectSymbolsDefinedInThisFile()
+    public function testWillCollectSymbolsDefinedInThisFile(): void
     {
         $this->traverseClassAST(self::class);
 
@@ -55,7 +55,7 @@ final class DefinedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testWillCollectFunctionDefinition()
+    public function testWillCollectFunctionDefinition(): void
     {
         $this->traverseStringAST('function foo() {}');
 
@@ -65,7 +65,7 @@ final class DefinedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testWillCollectNamespacedFunctionDefinition()
+    public function testWillCollectNamespacedFunctionDefinition(): void
     {
         $this->traverseStringAST('namespace Foo; function foo() {}');
 
@@ -75,7 +75,7 @@ final class DefinedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testWillCollectConstDefinition()
+    public function testWillCollectConstDefinition(): void
     {
         $this->traverseStringAST('const foo = "bar", baz = "tab";');
 
@@ -85,7 +85,7 @@ final class DefinedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testWillCollectNamespacedConstDefinition()
+    public function testWillCollectNamespacedConstDefinition(): void
     {
         $this->traverseStringAST('namespace Foo; const foo = "bar", baz = "tab";');
 
@@ -95,7 +95,7 @@ final class DefinedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testWillCollectDefinedConstDefinition()
+    public function testWillCollectDefinedConstDefinition(): void
     {
         $this->traverseStringAST('define("CONST_A", "MY_VALUE"); define("FooSpace\CONST_A", "BAR"); define($foo, "BAR");');
 
@@ -105,7 +105,7 @@ final class DefinedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testWillNotCollectNamespacedDefineCalls()
+    public function testWillNotCollectNamespacedDefineCalls(): void
     {
         $this->traverseStringAST('namespace Foo { function define($bar, $baz) {return;} define("NOT_A_CONST", "NOT_SOMETHING"); }');
 
@@ -115,7 +115,7 @@ final class DefinedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testTraitAdaptionDefinition()
+    public function testTraitAdaptionDefinition(): void
     {
         $this->traverseStringAST('namespace Foo; trait BarTrait { protected function test(){}} class UseTrait { use BarTrait {test as public;} }');
 
@@ -140,7 +140,7 @@ final class DefinedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    private static function assertSameCollectedSymbols(array $expected, array $actual)
+    private static function assertSameCollectedSymbols(array $expected, array $actual): void
     {
         self::assertSame(array_diff($expected, $actual), array_diff($actual, $expected));
     }

--- a/test/ComposerRequireCheckerTest/NodeVisitor/DefinedSymbolCollectorTest.php
+++ b/test/ComposerRequireCheckerTest/NodeVisitor/DefinedSymbolCollectorTest.php
@@ -35,7 +35,7 @@ class DefinedSymbolCollectorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->collector = new DefinedSymbolCollector();
         $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
@@ -45,14 +45,14 @@ class DefinedSymbolCollectorTest extends TestCase
         $this->traverser->addVisitor($this->collector);
     }
 
-    public function testExceptionWhenNoNamespaceDefined()
+    public function testExceptionWhenNoNamespaceDefined(): void
     {
         $this->expectException(\UnexpectedValueException::class);
         $node = new Class_('gedöns');
         $this->collector->enterNode($node);
     }
 
-    public function testRecordDefinedConstDefinition()
+    public function testRecordDefinedConstDefinition(): void
     {
         $node = new FuncCall(new Name('define'), [
             new Arg(new String_('CONST_A')),
@@ -63,7 +63,7 @@ class DefinedSymbolCollectorTest extends TestCase
         $this->assertContains('CONST_A', $this->collector->getDefinedSymbols());
     }
 
-    public function testDontRecordNamespacedDefinedConstDefinition()
+    public function testDontRecordNamespacedDefinedConstDefinition(): void
     {
         $node = new FuncCall(new Name('define', ['namespacedName' => new Name\FullyQualified('Foo\define')]), [
             new Arg(new String_('NO_CONST')),

--- a/test/ComposerRequireCheckerTest/NodeVisitor/UsedSymbolCollectorFunctionalTest.php
+++ b/test/ComposerRequireCheckerTest/NodeVisitor/UsedSymbolCollectorFunctionalTest.php
@@ -62,6 +62,7 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
                 'PhpParser\NodeVisitor\NameResolver',
                 'string',
                 'array',
+                'void',
             ],
             $this->collector->getCollectedSymbols()
         );

--- a/test/ComposerRequireCheckerTest/NodeVisitor/UsedSymbolCollectorFunctionalTest.php
+++ b/test/ComposerRequireCheckerTest/NodeVisitor/UsedSymbolCollectorFunctionalTest.php
@@ -35,7 +35,7 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->collector = new UsedSymbolCollector();
         $this->parser    = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
@@ -45,7 +45,7 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
         $this->traverser->addVisitor($this->collector);
     }
 
-    public function testWillCollectSymbolsUsedInThisFile()
+    public function testWillCollectSymbolsUsedInThisFile(): void
     {
         $this->traverseClassAST(self::class);
 
@@ -67,7 +67,7 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testWillCollectFunctionDefinitionTypes()
+    public function testWillCollectFunctionDefinitionTypes(): void
     {
         $this->traverseStringAST('<?php function foo(My\ParameterType $bar, array $fooBar) {}');
 
@@ -80,7 +80,7 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testWillCollectMethodDefinitionTypes()
+    public function testWillCollectMethodDefinitionTypes(): void
     {
         $this->traverseStringAST('<?php class Foo { function foo(My\ParameterType $bar, array $fooBar) {}}');
 
@@ -93,7 +93,7 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testWillCollectFunctionReturnTypes()
+    public function testWillCollectFunctionReturnTypes(): void
     {
         $this->traverseStringAST('<?php function foo($bar) : My\ReturnType {}');
 
@@ -105,7 +105,7 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testWillCollectMethodReturnTypes()
+    public function testWillCollectMethodReturnTypes(): void
     {
         $this->traverseStringAST('<?php class Foo { function foo($bar) : My\ReturnType {}}');
 
@@ -117,7 +117,7 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testWillCollectSimpleFunctionReturnTypes()
+    public function testWillCollectSimpleFunctionReturnTypes(): void
     {
         $this->traverseStringAST('<?php function foo($bar) : int {}');
 
@@ -129,7 +129,7 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testWontCollectAnyUsageTypes()
+    public function testWontCollectAnyUsageTypes(): void
     {
         $this->traverseStringAST('<?php function foo($bar) {}');
 
@@ -139,7 +139,7 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    public function testUseTraitAdaptionAlias()
+    public function testUseTraitAdaptionAlias(): void
     {
         $this->traverseStringAST('<?php namespace Foo; trait BarTrait { protected function test(){}} class UseTrait { use BarTrait {test as public;} }');
 
@@ -165,7 +165,7 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
         );
     }
 
-    private static function assertSameCollectedSymbols(array $expected, array $actual)
+    private static function assertSameCollectedSymbols(array $expected, array $actual): void
     {
         self::assertSame(array_diff($expected, $actual), array_diff($actual, $expected));
     }

--- a/test/ComposerRequireCheckerTest/NodeVisitor/UsedSymbolCollectorTest.php
+++ b/test/ComposerRequireCheckerTest/NodeVisitor/UsedSymbolCollectorTest.php
@@ -30,14 +30,14 @@ class UsedSymbolCollectorTest extends TestCase
     /** @var UsedSymbolCollector */
     private $visitor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->visitor = new UsedSymbolCollector();
     }
 
-    public function testExtendingClass()
+    public function testExtendingClass(): void
     {
         $node = new Class_('Foo');
         $node->extends = new Name('Bar');
@@ -49,7 +49,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Bar', $symbols);
     }
 
-    public function testExtendingInterface()
+    public function testExtendingInterface(): void
     {
         $node = new Interface_('Foo');
         $node->extends = [new Name('Bar'), new Name('Baz')];
@@ -62,7 +62,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Baz', $symbols);
     }
 
-    public function testImplements()
+    public function testImplements(): void
     {
         $node = new Class_('Foo');
         $node->implements = [new Name('Bar'), new Name('Baz')];
@@ -75,7 +75,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Baz', $symbols);
     }
 
-    public function testStaticCall()
+    public function testStaticCall(): void
     {
         $class = new Name('Foo');
         $node = new StaticCall($class, 'foo');
@@ -88,7 +88,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Foo', $symbols);
     }
 
-    public function testStaticPropertyFetch()
+    public function testStaticPropertyFetch(): void
     {
         $class = new Name('Foo');
         $node = new StaticPropertyFetch($class, 'foo');
@@ -101,7 +101,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Foo', $symbols);
     }
 
-    public function testClassConstantFetch()
+    public function testClassConstantFetch(): void
     {
         $class = new Name('Foo');
         $node = new ClassConstFetch($class, 'FOO');
@@ -114,7 +114,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Foo', $symbols);
     }
 
-    public function testNew()
+    public function testNew(): void
     {
         $class = new Name('Foo');
         $node = new New_($class);
@@ -127,7 +127,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Foo', $symbols);
     }
 
-    public function testInstanceof()
+    public function testInstanceof(): void
     {
         $class = new Name('Foo');
         $node = new Instanceof_(new Variable('foo'), $class);
@@ -140,7 +140,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Foo', $symbols);
     }
 
-    public function testCatch()
+    public function testCatch(): void
     {
         $class = new Name('Foo');
         $node = new Catch_([$class], new Variable('e'));
@@ -152,7 +152,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Foo', $symbols);
     }
 
-    public function testFunctionCallUsage()
+    public function testFunctionCallUsage(): void
     {
         $functionName = new Name('foo');
         $node = new FuncCall($functionName);
@@ -165,7 +165,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('foo', $symbols);
     }
 
-    public function testFunctionParameterType()
+    public function testFunctionParameterType(): void
     {
         $functionName = new Name('foo');
         $node = new Function_($functionName);
@@ -181,7 +181,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Baz', $symbols);
     }
 
-    public function testFunctionParameterTypeAsString()
+    public function testFunctionParameterTypeAsString(): void
     {
         $functionName = new Name('foo');
         $node = new Function_($functionName);
@@ -197,7 +197,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Baz', $symbols);
     }
 
-    public function testMethodParameterType()
+    public function testMethodParameterType(): void
     {
         $functionName = new Name('foo');
         $node = new ClassMethod($functionName);
@@ -213,7 +213,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Baz', $symbols);
     }
 
-    public function testMethodParameterTypeAsString()
+    public function testMethodParameterTypeAsString(): void
     {
         $functionName = new Name('foo');
         $node = new ClassMethod($functionName);
@@ -229,7 +229,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Baz', $symbols);
     }
 
-    public function testFunctionReturnType()
+    public function testFunctionReturnType(): void
     {
         $functionName = new Name('foo');
         $node = new Function_($functionName);
@@ -242,7 +242,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Bar', $symbols);
     }
 
-    public function testFunctionReturnTypeAsString()
+    public function testFunctionReturnTypeAsString(): void
     {
         $functionName = new Name('foo');
         $node = new Function_($functionName);
@@ -255,7 +255,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Bar', $symbols);
     }
 
-    public function testMethodReturnType()
+    public function testMethodReturnType(): void
     {
         $functionName = new Name('foo');
         $node = new ClassMethod($functionName);
@@ -268,7 +268,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Bar', $symbols);
     }
 
-    public function testMethodReturnTypeAsString()
+    public function testMethodReturnTypeAsString(): void
     {
         $functionName = new Name('foo');
         $node = new ClassMethod($functionName);
@@ -281,7 +281,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Bar', $symbols);
     }
 
-    public function testConstantFetch()
+    public function testConstantFetch(): void
     {
         $exceptionClass = new Name('FooException');
         $node = new ConstFetch($exceptionClass);
@@ -294,7 +294,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('FooException', $symbols);
     }
 
-    public function testTraits()
+    public function testTraits(): void
     {
         $node = new TraitUse([new Name('Foo')]);
 
@@ -305,7 +305,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Foo', $symbols);
     }
 
-    public function testTraitUseVisibilityAdaptation()
+    public function testTraitUseVisibilityAdaptation(): void
     {
         $traitUseAdaption = new Alias(null, 'testMethod', Class_::MODIFIER_PUBLIC, null);
         $traitUse = new TraitUse([new Name('Foo')], [$traitUseAdaption]);
@@ -317,7 +317,7 @@ class UsedSymbolCollectorTest extends TestCase
         $this->assertContains('Foo', $symbols);
     }
 
-    public function testBeforeTraverseResetsRecordedSymbols()
+    public function testBeforeTraverseResetsRecordedSymbols(): void
     {
         $node = new Class_('Foo');
         $node->extends = new Name('Bar');

--- a/test/ComposerRequireCheckerTest/UsedSymbolsLocator/LocateUsedSymbolsFromASTRootsTest.php
+++ b/test/ComposerRequireCheckerTest/UsedSymbolsLocator/LocateUsedSymbolsFromASTRootsTest.php
@@ -16,14 +16,14 @@ class LocateUsedSymbolsFromASTRootsTest extends TestCase
     /** @var LocateUsedSymbolsFromASTRoots */
     private $locator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->locator = new LocateUsedSymbolsFromASTRoots();
     }
 
-    public function testNoAsts()
+    public function testNoAsts(): void
     {
         $asts = [];
         $symbols = $this->locate($asts);
@@ -31,7 +31,7 @@ class LocateUsedSymbolsFromASTRootsTest extends TestCase
         $this->assertCount(0, $symbols);
     }
 
-    public function testLocate()
+    public function testLocate(): void
     {
         $node = new Class_('Foo');
         $node->extends = new Name('Bar');


### PR DESCRIPTION
This PR

* [x] adds `void` return type declarations to test methods
* [x] fixes a failing test

💁‍♂ I ran

```
$ composer global require friendsofphp/php-cs-fixer
```

followed by

```
$ php-cs-fixer fix --allow-risky=yes --rules=void_return test
```