### PR TITLE
Fix: Do not update composer itself twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ matrix:
 
 before_install:
     - export COMPOSER_GLOBAL_HOME_DIR=`composer config -g home`
-    - composer self-update
     - sed s\@TRAVIS_BUILD_DIR@$TRAVIS_BUILD_DIR@g test/travis-composer.json > ${COMPOSER_GLOBAL_HOME_DIR}/composer.json
 
 install:


### PR DESCRIPTION
This PR

* [x] stops updating `composer` itself twice on Travis

💁‍♂ For reference, see

* https://travis-ci.org/maglnet/ComposerRequireChecker/jobs/569566549#L224
* https://travis-ci.org/maglnet/ComposerRequireChecker/jobs/569566549#L238