### PR TITLE
Fix: Exclude test fixtures from scrutiny of Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,10 @@
 imports:
     - php
 
+filter:
+    excluded_paths:
+        - 'test/fixtures'
+
 tools:
     external_code_coverage:
         timeout: 600


### PR DESCRIPTION
This PR

* [x] excludes test fixtures from the scrutiny of Scrutinizer

Related to #117.

👊 