### PR TITLE
Fix: Reduce visibility of setUp()

### DIFF
--- a/test/ComposerRequireCheckerTest/BinaryTest.php
+++ b/test/ComposerRequireCheckerTest/BinaryTest.php
@@ -10,7 +10,7 @@ class BinaryTest extends TestCase
     /** @var string */
     private $bin;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->bin = __DIR__ . "/../../bin/composer-require-checker";
     }

--- a/test/ComposerRequireCheckerTest/Cli/ApplicationTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/ApplicationTest.php
@@ -14,7 +14,7 @@ class ApplicationTest extends TestCase
      */
     private $application;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->application = new Application();
     }

--- a/test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php
@@ -16,7 +16,7 @@ class CheckCommandTest extends TestCase
      */
     private $commandTester;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $application = new Application();
         $command = $application->get('check');

--- a/test/ComposerRequireCheckerTest/DependencyGuesser/DependencyGuesserTest.php
+++ b/test/ComposerRequireCheckerTest/DependencyGuesser/DependencyGuesserTest.php
@@ -14,7 +14,7 @@ class DependencyGuesserTest extends TestCase
      */
     private $guesser;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->guesser = new DependencyGuesser();
     }

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateFilesByGlobPatternTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateFilesByGlobPatternTest.php
@@ -21,7 +21,7 @@ class LocateFilesByGlobPatternTest extends TestCase
      */
     private $root;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->locator = new LocateFilesByGlobPattern();
         $this->root = vfsStream::setup();


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` in tests

💁‍♂ I ran

```
$ composer global require friendsofphp/php-cs-fixer
```

followed by

```
$ php-cs-fixer fix --allow-risky=yes --rules=php_unit_set_up_tear_down_visibility test
```