### PR TITLE
Enhancement: Keep packages sorted in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "phpunit/phpunit": "^6.0"
     },
     "config": {
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This PR

* [x] configures the `sort-packages` option to keep packages sorted for future operations on `composer.json`

Follows #122.