### PR TITLE
Enhancement: Reference phpunit.xsd as installed with composer

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="./vendor/autoload.php"
     colors="true"
     convertErrorsToExceptions="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,6 @@
     stopOnFailure="false"
     processIsolation="false"
     backupGlobals="false"
-    syntaxCheck="true"
 >
     <testsuite name="ComposerRequireChecker tests">
         <directory>./test/ComposerRequireCheckerTest</directory>


### PR DESCRIPTION
This PR

* [x] references `phpunit.xsd` as installed with `composer`
* [x] removes a non-existent attribute from `phpunit.xml.dist`

💁‍♂ Helps with auto-completion!