### PR TITLE
Fix: Drop support for PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,10 @@ git:
 matrix:
     fast_finish: true
     include:
-        - php: 7.1
+        - php: 7.2
           env:
             - COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
             - COVERAGE=1
-        - php: 7.2
         - php: 7.3
         - php: nightly
     allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- drop support for PHP 7.1 - #127
 
 ## [2.0.0] - 2019-03-19
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "ext-json": "*",
         "ext-phar": "*",
         "nikic/php-parser": "^4.0",


### PR DESCRIPTION
This PR

* [x] drops support for PHP 7.1

Related to https://github.com/maglnet/ComposerRequireChecker/pull/126#discussion_r312696453.