### PR TITLE
Fix: Configure path to PHPUnit result cache file

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="./vendor/autoload.php"
+    cacheResultFile="build/.phpunit.result.cache"
     colors="true"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"


### PR DESCRIPTION
This PR

* [x] configures the path to `.phpunit.result.cache`

💁‍♂ Missed this in #126.