### PR TITLE
Try to guess packages using BetterReflection.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "ext-json": "*",
         "ext-phar": "*",
         "nikic/php-parser": "^4.3",
+        "roave/better-reflection": "^3.5.0",
         "ocramius/package-versions": "^1.4.2",
         "symfony/console": "^5.0",
         "webmozart/glob": "^4.1"

--- a/src/ComposerRequireChecker/Cli/CheckCommand.php
+++ b/src/ComposerRequireChecker/Cli/CheckCommand.php
@@ -7,6 +7,7 @@ use ComposerRequireChecker\DefinedExtensionsResolver\DefinedExtensionsResolver;
 use ComposerRequireChecker\DefinedSymbolsLocator\LocateDefinedSymbolsFromASTRoots;
 use ComposerRequireChecker\DefinedSymbolsLocator\LocateDefinedSymbolsFromExtensions;
 use ComposerRequireChecker\DependencyGuesser\DependencyGuesser;
+use ComposerRequireChecker\DependencyGuesser\GuessFromComposerInstalledJson;
 use ComposerRequireChecker\FileLocator\LocateComposerPackageDirectDependenciesSourceFiles;
 use ComposerRequireChecker\FileLocator\LocateComposerPackageSourceFiles;
 use ComposerRequireChecker\FileLocator\LocateFilesByGlobPattern;
@@ -116,6 +117,7 @@ class CheckCommand extends Command
         $table = new Table($output);
         $table->setHeaders(['unknown symbol', 'guessed dependency']);
         $guesser = new DependencyGuesser($options);
+        $guesser->addGuesser(new GuessFromComposerInstalledJson(dirname($composerJson)));
         foreach ($unknownSymbols as $unknownSymbol) {
             $guessedDependencies = [];
             foreach ($guesser($unknownSymbol) as $guessedDependency) {

--- a/src/ComposerRequireChecker/DependencyGuesser/DependencyGuesser.php
+++ b/src/ComposerRequireChecker/DependencyGuesser/DependencyGuesser.php
@@ -17,6 +17,11 @@ class DependencyGuesser
         $this->guessers[] = new GuessFromLoadedExtensions($options);
     }
 
+    public function addGuesser(GuesserInterface $guesser): void
+    {
+        $this->guessers[] = $guesser;
+    }
+
     public function __invoke($symbolName): \Generator
     {
         foreach ($this->guessers as $guesser) {

--- a/src/ComposerRequireChecker/DependencyGuesser/GuessFromComposerInstalledJson.php
+++ b/src/ComposerRequireChecker/DependencyGuesser/GuessFromComposerInstalledJson.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+
+namespace ComposerRequireChecker\DependencyGuesser;
+
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Identifier\Identifier;
+use Roave\BetterReflection\Identifier\IdentifierType;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\MakeLocatorForInstalledJson;
+use Roave\BetterReflection\SourceLocator\Type\MemoizingSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
+
+final class GuessFromComposerInstalledJson implements GuesserInterface
+{
+    /**
+     * @var SourceLocator
+     */
+    private $sourceLocator;
+
+    /**
+     * @var ClassReflector
+     */
+    private $reflector;
+
+    /**
+     * @var string
+     */
+    private $pathRegex;
+
+    public function __construct(string $projectPath)
+    {
+        $this->sourceLocator = new MemoizingSourceLocator(
+            (new MakeLocatorForInstalledJson())(
+                $projectPath,
+                (new BetterReflection())->astLocator()
+            )
+        );
+
+        $this->reflector = new ClassReflector($this->sourceLocator);
+
+        // @todo: support https://getcomposer.org/doc/06-config.md#vendor-dir; useless as BetterReflection does not, at this moment.
+        $cleanPath = preg_quote(str_replace(DIRECTORY_SEPARATOR, '/', $projectPath) . '/' . 'vendor', '@');
+
+        $this->pathRegex = '@^' . $cleanPath . '/(?:composer/\.\./)?([^/]+/[^/]+)/@';
+    }
+
+    public function __invoke(string $symbolName): \Generator
+    {
+        $reflection = $this->sourceLocator->locateIdentifier($this->reflector, new Identifier($symbolName, new IdentifierType(IdentifierType::IDENTIFIER_CLASS)));
+
+        if (!($reflection instanceof ReflectionClass)) {
+            return;
+        }
+
+        $path = $reflection->getFileName();
+
+        if (preg_match($this->pathRegex, $path, $captures)) {
+            yield $captures[1];
+        }
+    }
+}

--- a/test/ComposerRequireCheckerTest/DependencyGuesser/DependencyGuesserTest.php
+++ b/test/ComposerRequireCheckerTest/DependencyGuesser/DependencyGuesserTest.php
@@ -4,7 +4,10 @@ namespace ComposerRequireCheckerTest\DependencyGuesser;
 
 use ComposerRequireChecker\Cli\Options;
 use ComposerRequireChecker\DependencyGuesser\DependencyGuesser;
+use ComposerRequireChecker\DependencyGuesser\GuesserInterface;
+use PhpParser\Node\Expr\ArrayItem;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
 
 final class DependencyGuesserTest extends TestCase
 {
@@ -42,5 +45,18 @@ final class DependencyGuesserTest extends TestCase
         $result = $this->guesser->__invoke('RecursiveDirectoryIterator');
         $this->assertNotEmpty($result);
         $this->assertContains('php', $result);
+    }
+
+    public function testUseAddedGuesser(): void
+    {
+        $additionalGuesser = $this->createStub(GuesserInterface::class);
+        $additionalGuesser->method('__invoke')
+            ->willReturnCallback(function (): \Generator {
+                yield 'additional-guesser-result';
+            });
+        $this->guesser->addGuesser($additionalGuesser);
+        $result = $this->guesser->__invoke('some_symbol');
+        $this->assertNotEmpty($result);
+        $this->assertContains('additional-guesser-result', $result);
     }
 }

--- a/test/ComposerRequireCheckerTest/DependencyGuesser/GuessFromComposerInstalledJsonTest.php
+++ b/test/ComposerRequireCheckerTest/DependencyGuesser/GuessFromComposerInstalledJsonTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace ComposerRequireCheckerTest\DependencyGuesser;
+
+use ComposerRequireChecker\DependencyGuesser\GuessFromComposerInstalledJson;
+use PHPUnit\Framework\TestCase;
+
+class GuessFromComposerInstalledJsonTest extends TestCase
+{
+    /**
+     * @var GuessFromComposerInstalledJson
+     */
+    private $guesser;
+
+    protected function setUp(): void
+    {
+        $this->guesser = new GuessFromComposerInstalledJson(dirname(__DIR__, 3));
+    }
+
+    public function testGuessVendorClass(): void
+    {
+        $result = ($this->guesser)(TestCase::class);
+
+        self::assertNotEmpty($result);
+        self::assertContains('phpunit/phpunit', $result);
+    }
+
+    public function testDoNotGuessVendorFunction(): void
+    {
+        $result = iterator_to_array(($this->guesser)('DeepCopy\deep_copy'));
+
+        self::assertEmpty($result);
+    }
+
+
+    public function testDoNotGuessClassFromProject(): void
+    {
+        $result = iterator_to_array(($this->guesser)(GuessFromComposerInstalledJson::class));
+
+        self::assertEmpty($result);
+    }
+}


### PR DESCRIPTION
See #52.

~~There are still a couple of issues:~~

~~* I do not like loading the project autoloader, since it automatically registers. Yet it is a cheap way to resolve symbols.~~
~~* I am not satisfied with the handling of the autoloader-path configuration.~~

Use BetterReflection to guess the source package of unknown symbols from the vendor directory.

Known limitations:
* Find classes only.
* Do not support non-standard vendor locations (https://getcomposer.org/doc/06-config.md#vendor-dir), since BetterReflection does not either.