### PR TITLE
Test that CheckCommand finds unknown symbols.

### DIFF
--- a/test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php
@@ -82,4 +82,19 @@ JSON
 
         $this->assertRegExp('/There were no unknown symbols found./', $this->commandTester->getDisplay());
     }
+
+    public function testSourceFileThatUsesDevDependency(): void
+    {
+        $root = vfsStream::setup();
+        vfsStream::create(['config.json' => '{"scan-files":["test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php"]}']);
+
+        $exitCode = $this->commandTester->execute([
+            // that's our own composer.json
+            'composer-json' => dirname(__DIR__, 3) . '/composer.json',
+            '--config-file' => $root->getChild('config.json')->url(),
+        ]);
+
+        $this->assertNotEquals(0, $exitCode);
+        $this->assertRegExp('/The following unknown symbols were found.*PHPUnit\\\\Framework\\\\TestCase/s', $this->commandTester->getDisplay());
+    }
 }


### PR DESCRIPTION
It runs CheckCommand using a source file from the test code, to ensure the check fails. This allows to test the "unknown symbol found" path of the CheckCommand.