### PR TITLE
Create GitHub workflows

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,61 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+name: "Static Analysis by PHPStan"
+
+on:
+    pull_request:
+    push:
+        branches:
+            - "master"
+
+jobs:
+    static-analysis-phpstan:
+        name: "Static Analysis by PHPStan"
+
+        runs-on: ${{ matrix.os }}
+
+        strategy:
+            matrix:
+                dependencies:
+                    - "locked"
+                php-version:
+                    - "7.2"
+                    - "7.3"
+                    - "7.4"
+                operating-system:
+                    - "ubuntu-latest"
+
+        steps:
+            - name: "Checkout"
+              uses: "actions/checkout@v2"
+
+            - name: "Install PHP"
+              uses: "shivammathur/setup-php@v2"
+              with:
+                  coverage: "pcov"
+                  php-version: "${{ matrix.php-version }}"
+                  ini-values: memory_limit=-1
+
+            - name: "Cache dependencies"
+              uses: "actions/cache@v2"
+              with:
+                  path: |
+                      ~/.composer/cache
+                      vendor
+                  key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
+                  restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
+
+            - name: "Install lowest dependencies"
+              if: ${{ matrix.dependencies == 'lowest' }}
+              run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest"
+
+            - name: "Install highest dependencies"
+              if: ${{ matrix.dependencies == 'highest' }}
+              run: "composer update --no-interaction --no-progress --no-suggest"
+
+            - name: "Install locked dependencies"
+              if: ${{ matrix.dependencies == 'locked' }}
+              run: "composer install --no-interaction --no-progress --no-suggest"
+
+            - name: "PHPStan"
+              run: "vendor/bin/phpstan analyse -l 5 src --memory-limit=-1"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -12,7 +12,7 @@ jobs:
     static-analysis-phpstan:
         name: "Static Analysis by PHPStan"
 
-        runs-on: ${{ matrix.os }}
+        runs-on: ${{ matrix.operating-system }}
 
         strategy:
             matrix:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -12,7 +12,7 @@ jobs:
     phpunit:
         name: "PHPUnit tests"
 
-        runs-on: ${{ matrix.os }}
+        runs-on: ${{ matrix.operating-system }}
 
         strategy:
             matrix:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,64 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+name: "PHPUnit tests"
+
+on:
+    pull_request:
+    push:
+        branches:
+            - "master"
+
+jobs:
+    phpunit:
+        name: "PHPUnit tests"
+
+        runs-on: ${{ matrix.os }}
+
+        strategy:
+            matrix:
+                dependencies:
+                    - "lowest"
+                    - "highest"
+                    - "locked"
+                php-version:
+                    - "7.2"
+                    - "7.3"
+                    - "7.4"
+                operating-system:
+                    - "ubuntu-latest"
+                    - "windows-latest"
+
+        steps:
+            - name: "Checkout"
+              uses: "actions/checkout@v2"
+
+            - name: "Install PHP"
+              uses: "shivammathur/setup-php@v2"
+              with:
+                  coverage: "pcov"
+                  php-version: "${{ matrix.php-version }}"
+                  ini-values: memory_limit=-1
+
+            - name: "Cache dependencies"
+              uses: "actions/cache@v2"
+              with:
+                  path: |
+                      ~/.composer/cache
+                      vendor
+                  key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
+                  restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
+
+            - name: "Install lowest dependencies"
+              if: ${{ matrix.dependencies == 'lowest' }}
+              run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest"
+
+            - name: "Install highest dependencies"
+              if: ${{ matrix.dependencies == 'highest' }}
+              run: "composer update --no-interaction --no-progress --no-suggest"
+
+            - name: "Install locked dependencies"
+              if: ${{ matrix.dependencies == 'locked' }}
+              run: "composer install --no-interaction --no-progress --no-suggest"
+
+            - name: "Tests"
+              run: "vendor/bin/phpunit --coverage-clover=clover.xml --coverage-text"

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -14,7 +14,7 @@ jobs:
     static-analysis-psalm:
         name: "Static Analysis by Psalm"
 
-        runs-on: ${{ matrix.os }}
+        runs-on: ${{ matrix.operating-system }}
 
         strategy:
             matrix:

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,0 +1,61 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+name: "Static Analysis by Psalm"
+
+on:
+    pull_request:
+    push:
+        branches:
+            - "master"
+
+jobs:
+    static-analysis-psalm:
+        name: "Static Analysis by Psalm"
+
+        runs-on: ${{ matrix.os }}
+
+        strategy:
+            matrix:
+                dependencies:
+                    - "locked"
+                php-version:
+                    - "7.2"
+                    - "7.3"
+                    - "7.4"
+                operating-system:
+                    - "ubuntu-latest"
+
+        steps:
+            - name: "Checkout"
+              uses: "actions/checkout@v2"
+
+            - name: "Install PHP"
+              uses: "shivammathur/setup-php@v2"
+              with:
+                  coverage: "pcov"
+                  php-version: "${{ matrix.php-version }}"
+                  ini-values: memory_limit=-1
+
+            - name: "Cache dependencies"
+              uses: "actions/cache@v2"
+              with:
+                  path: |
+                      ~/.composer/cache
+                      vendor
+                  key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
+                  restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
+
+            - name: "Install lowest dependencies"
+              if: ${{ matrix.dependencies == 'lowest' }}
+              run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest"
+
+            - name: "Install highest dependencies"
+              if: ${{ matrix.dependencies == 'highest' }}
+              run: "composer update --no-interaction --no-progress --no-suggest"
+
+            - name: "Install locked dependencies"
+              if: ${{ matrix.dependencies == 'locked' }}
+              run: "composer install --no-interaction --no-progress --no-suggest"
+
+            - name: "psalm"
+              run: "vendor/bin/psalm --shepherd --stats"

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -4,6 +4,8 @@ name: "Static Analysis by Psalm"
 
 on:
     pull_request:
+        branches:
+            - "master"
     push:
         branches:
             - "master"

--- a/.github/workflows/require-checker.yml
+++ b/.github/workflows/require-checker.yml
@@ -1,0 +1,59 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+name: "Static Analysis by Require-Checker"
+
+on:
+    pull_request:
+    push:
+        branches:
+            - "master"
+
+jobs:
+    static-analysis-require-checker:
+        name: "Static Analysis by Require-Checker"
+
+        runs-on: ${{ matrix.os }}
+
+        strategy:
+            matrix:
+                dependencies:
+                    - "locked"
+                php-version:
+                    - "7.4"
+                operating-system:
+                    - "ubuntu-latest"
+
+        steps:
+            - name: "Checkout"
+              uses: "actions/checkout@v2"
+
+            - name: "Install PHP"
+              uses: "shivammathur/setup-php@v2"
+              with:
+                  coverage: "pcov"
+                  php-version: "${{ matrix.php-version }}"
+                  ini-values: memory_limit=-1
+
+            - name: "Cache dependencies"
+              uses: "actions/cache@v2"
+              with:
+                  path: |
+                      ~/.composer/cache
+                      vendor
+                  key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
+                  restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
+
+            - name: "Install lowest dependencies"
+              if: ${{ matrix.dependencies == 'lowest' }}
+              run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest"
+
+            - name: "Install highest dependencies"
+              if: ${{ matrix.dependencies == 'highest' }}
+              run: "composer update --no-interaction --no-progress --no-suggest"
+
+            - name: "Install locked dependencies"
+              if: ${{ matrix.dependencies == 'locked' }}
+              run: "composer install --no-interaction --no-progress --no-suggest"
+
+            - name: "self-check"
+              run: "bin/composer-require-checker"

--- a/.github/workflows/require-checker.yml
+++ b/.github/workflows/require-checker.yml
@@ -12,7 +12,7 @@ jobs:
     static-analysis-require-checker:
         name: "Static Analysis by Require-Checker"
 
-        runs-on: ${{ matrix.os }}
+        runs-on: ${{ matrix.operating-system }}
 
         strategy:
             matrix:


### PR DESCRIPTION
This PR aims to add GitHub workflows in favor of travis and appveyor.
I think  all the ci jobs are ported from travis beside of the nightly build check. I dont know if a solution exists atm but last time i checked this was not really possible in a "clean" way. See: https://github.com/actions/runner/issues/2347

I also realized that we dont have any cs check atm. Maybe we should add them in the near future?

Also i think Action are not enabled yet here. See my test PR on my Repo for the output: https://github.com/DanielBadura/ComposerRequireChecker/pull/2
I mostly check at BetterReflection as a reference since I work more with GitLab-CI 🤖 

I quite dont understand this part:
```
on:
    pull_request:
    push:
        branches:
            - "master"
```

Is `on: pull_request: branches: [master]` the default? Because i would think with this config workflow should only run if commits gets pushed into master. So i would expect this:

```
on:
    pull_request:
        branches:
            - "master"
    push:
        branches:
            - "master"
```

Because no job ran on the first commit i tried it in the psalm workflow but without success. So i figured that action are not enabled here and checked on my repo. There all workflows are running on the PR with or without `on: pull_request: branches: [master]`