### PR TITLE
Catch PHP Parser error and rethrow it with file information

### DIFF
--- a/src/ComposerRequireChecker/ASTLocator/LocateASTFromFiles.php
+++ b/src/ComposerRequireChecker/ASTLocator/LocateASTFromFiles.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ComposerRequireChecker\ASTLocator;
 
+use ComposerRequireChecker\Exception\FileParseFailed;
+use PhpParser\Error;
 use PhpParser\ErrorHandler;
 use PhpParser\Node\Stmt;
 use PhpParser\Parser;
@@ -37,7 +39,12 @@ final class LocateASTFromFiles
                 continue;
             }
 
-            $stmts = $this->parser->parse(file_get_contents($file), $this->errorHandler);
+            try {
+                $stmts = $this->parser->parse(file_get_contents($file), $this->errorHandler);
+            } catch (Error $e) {
+                // Convert the parse error into one which has the file information
+                throw new FileParseFailed($file, $e);
+            }
 
             if ($stmts === null) {
                 throw new RuntimeException(sprintf('Parsing the file [%s] resulted in an error.', $file));

--- a/src/ComposerRequireChecker/Exception/FileParseFailed.php
+++ b/src/ComposerRequireChecker/Exception/FileParseFailed.php
@@ -7,10 +7,13 @@ namespace ComposerRequireChecker\Exception;
 use RuntimeException;
 use Throwable;
 
+use function sprintf;
+
 class FileParseFailed extends RuntimeException
 {
     public function __construct(string $file, ?Throwable $previous = null)
     {
-        parent::__construct($file . ': ' . $previous->getMessage(), 0, $previous);
+        $msg = sprintf('Parsing the file [%s] resulted in an error: %s', $file, $previous->getMessage());
+        parent::__construct($msg, 0, $previous);
     }
 }

--- a/src/ComposerRequireChecker/Exception/FileParseFailed.php
+++ b/src/ComposerRequireChecker/Exception/FileParseFailed.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerRequireChecker\Exception;
+
+use RuntimeException;
+use Throwable;
+
+class FileParseFailed extends RuntimeException
+{
+    public function __construct(string $file, ?Throwable $previous = null)
+    {
+        parent::__construct($file . ': ' . $previous->getMessage(), 0, $previous);
+    }
+}

--- a/test/ComposerRequireCheckerTest/ASTLocator/LocateASTFromFilesTest.php
+++ b/test/ComposerRequireCheckerTest/ASTLocator/LocateASTFromFilesTest.php
@@ -51,7 +51,7 @@ final class LocateASTFromFilesTest extends TestCase
     public function testFailOnParseError(): void
     {
         $this->expectException(FileParseFailed::class);
-        $this->expectExceptionMessageMatches('/^vfs:\/\/root\/MyBadCode: /');
+        $this->expectExceptionMessageMatches('/\[vfs:\/\/root\/MyBadCode\]/');
         $files = [
             $this->createFile('MyBadCode', '<?php this causes a parse error'),
         ];

--- a/test/ComposerRequireCheckerTest/ASTLocator/LocateASTFromFilesTest.php
+++ b/test/ComposerRequireCheckerTest/ASTLocator/LocateASTFromFilesTest.php
@@ -6,9 +6,9 @@ namespace ComposerRequireCheckerTest\ASTLocator;
 
 use ArrayObject;
 use ComposerRequireChecker\ASTLocator\LocateASTFromFiles;
+use ComposerRequireChecker\Exception\FileParseFailed;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
-use PhpParser\Error;
 use PhpParser\ErrorHandler\Collecting;
 use PhpParser\Lexer;
 use PhpParser\Node\Stmt;
@@ -50,7 +50,8 @@ final class LocateASTFromFilesTest extends TestCase
 
     public function testFailOnParseError(): void
     {
-        $this->expectException(Error::class);
+        $this->expectException(FileParseFailed::class);
+        $this->expectExceptionMessageMatches('/^vfs:\/\/root\/MyBadCode: /');
         $files = [
             $this->createFile('MyBadCode', '<?php this causes a parse error'),
         ];


### PR DESCRIPTION
Should fix #272.

This change ensures the Parser error is catched and its message is prepended with the file path of the file currently being parsed.