### PR TITLE
Fix incorrect XDEBUG_MODE in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ If this is already done, run it like this:
 composer-require-checker check /path/to/your/project/composer.json
 ```
 
-### A note about XDebug
+### A note about Xdebug
 
-If your PHP is including XDebug when running ComposerRequireChecker, you may experience additional issues like exceeding the XDebug-related max-nesting-level - and on top, XDebug slows PHP down.
+If your PHP is including Xdebug when running ComposerRequireChecker, you may experience additional issues like exceeding the Xdebug-related max-nesting-level - and on top, Xdebug slows PHP down.
 
-It is recommended to run ComposerRequireChecker without XDebug. 
+It is recommended to run ComposerRequireChecker without Xdebug. 
 
-If you cannot provide a PHP instance without XDebug yourself, try setting an environment variable like this for just the command: `XDEBUG_MODE=none php composer-require-checker`.
+If you cannot provide a PHP instance without Xdebug yourself, try setting an environment variable like this for just the command: `XDEBUG_MODE=off php composer-require-checker`.
 
 ## Configuration
 


### PR DESCRIPTION
This is a follow up for https://github.com/maglnet/ComposerRequireChecker/pull/284 and https://github.com/maglnet/ComposerRequireChecker/pull/282

* Replaces `XDEBUG_MODE=none` with `XDEBUG_MODE=off` since `none` [is not a supported mode](https://xdebug.org/docs/all_settings#mode)
* Replaces `XDebug` with `Xdebug` since this is how it's officially named


If I use `XDEBUG_MODE=none`, I get:

```
Xdebug: [Config] Invalid mode 'none' set for 'XDEBUG_MODE' environment variable, fall back to 'xdebug.mode' configuration setting (See: https://xdebug.org/docs/errors#CFG-C-ENVMODE)
Xdebug: [Config] Invalid mode 'none' set for 'xdebug.mode' configuration setting (See: https://xdebug.org/docs/errors#CFG-C-MODE)
Xdebug: [Config] Invalid mode 'none' set for 'XDEBUG_MODE' environment variable, fall back to 'xdebug.mode' configuration setting (See: https://xdebug.org/docs/errors#CFG-C-ENVMODE)
```

---

By the way, if you are curios, difference between running composer-require-checker with and without xdebug enabled:

```
time vendor/bin/composer-require-checker --config-file=composer-checker.json

real    0m 38.76s
```

```
time XDEBUG_MODE=off php vendor/bin/composer-require-checker --config-file=composer-checker.json

real    0m 18.44s
```

so it's 2x times faster