### PR TITLE
For unix-y phar file, always use unix-y line endings

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -57,7 +57,7 @@
     <!-- ============================================  -->
     <target name="phar-build" depends="run-test">
         <!--create the package-->
-        <php expression="file_put_contents('bin/clistub.php', '#!/usr/bin/env php' . PHP_EOL . Phar::createDefaultStub('bin/composer-require-checker.php'))"/>
+        <php expression="file_put_contents('bin/clistub.php', '#!/usr/bin/env php' . chr(10) . Phar::createDefaultStub('bin/composer-require-checker.php'))"/>
         <pharpackage basedir="./"
                      destfile="${build-dir}/${phing.project.name}.phar"
                      stub="bin/clistub.php"


### PR DESCRIPTION
When being built under systems having different PHP_EOL than \r,
a phar will be built not working _usually_ under unix-alike system.

Fixes https://github.com/maglnet/ComposerRequireChecker/issues/281

---
I made this PR against the 3.3.x branch, because this is the one where the latest release is from.