### PR TITLE
Record definition of enums

### DIFF
--- a/src/ComposerRequireChecker/NodeVisitor/DefinedSymbolCollector.php
+++ b/src/ComposerRequireChecker/NodeVisitor/DefinedSymbolCollector.php
@@ -42,6 +42,7 @@ final class DefinedSymbolCollector extends NodeVisitorAbstract
     public function enterNode(Node $node): Node
     {
         $this->recordClassDefinition($node);
+        $this->recordEnumDefinition($node);
         $this->recordInterfaceDefinition($node);
         $this->recordTraitDefinition($node);
         $this->recordFunctionDefinition($node);
@@ -54,6 +55,15 @@ final class DefinedSymbolCollector extends NodeVisitorAbstract
     private function recordClassDefinition(Node $node): void
     {
         if (! ($node instanceof Node\Stmt\Class_) || $node->isAnonymous()) {
+            return;
+        }
+
+        $this->recordDefinitionOf($node);
+    }
+
+    private function recordEnumDefinition(Node $node): void
+    {
+        if (! ($node instanceof Node\Stmt\Enum)) {
             return;
         }
 


### PR DESCRIPTION
Records definition of enums so they are no longer shown as unknown symbols.  Probably needs some more work in https://github.com/maglnet/ComposerRequireChecker/blob/3.6.x/src/ComposerRequireChecker/NodeVisitor/UsedSymbolCollector.php so that it can record symbols used by enums - but this is a start.