### PR TITLE
Add PHP 8.1 to test matrix

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -23,6 +23,7 @@ jobs:
                 php-version:
                     - "7.4"
                     - "8.0"
+                    - "8.1"
                 operating-system:
                     - "ubuntu-latest"
                     - "windows-latest"


### PR DESCRIPTION
To make composer-require-checker working with PHP 8.1 the first step IMHO should be to add PHP 8.1 to the test matrix and make sure that the current implementation works.

Afterwards additional features like "understanding enum symbols" can be added (not subject of this PR).