### PR TITLE
Define allowed plugins for `composer/composer:2.2.0` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,10 @@
     },
     "config": {
         "optimize-autoloader": true,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Needed for Composer 2.2.0 (found with 2.2.0-RC1)