### PR TITLE
#354 Make sure language types are always in the symbol whitelist

### DIFF
--- a/data/config.dist.json
+++ b/data/config.dist.json
@@ -1,9 +1,5 @@
 {
-  "symbol-whitelist" : [
-    "null", "true", "false",
-    "static", "self", "parent",
-    "array", "string", "int", "float", "bool", "iterable", "callable", "void", "object", "mixed", "never"
-  ],
+  "symbol-whitelist" : [],
   "php-core-extensions" : [
     "Core",
     "date",

--- a/src/ComposerRequireChecker/Cli/Options.php
+++ b/src/ComposerRequireChecker/Cli/Options.php
@@ -7,6 +7,8 @@ namespace ComposerRequireChecker\Cli;
 use ComposerRequireChecker\FileLocator\LocateComposerPackageSourceFiles;
 use InvalidArgumentException;
 
+use function array_merge;
+use function array_unique;
 use function method_exists;
 use function str_replace;
 use function ucwords;
@@ -16,8 +18,7 @@ use function ucwords;
  */
 class Options
 {
-    /** @var array<string>  */
-    private array $symbolWhitelist = [
+    private const PHP_LANGUAGE_TYPES = [
         'null',
         'true',
         'false', // consts
@@ -36,6 +37,9 @@ class Options
         'mixed',
         'never',
     ];
+
+    /** @var array<string>  */
+    private array $symbolWhitelist = self::PHP_LANGUAGE_TYPES;
 
     /** @var array<string>  */
     private array $phpCoreExtensions = [
@@ -97,7 +101,14 @@ class Options
      */
     public function setSymbolWhitelist(array $symbolWhitelist): void
     {
-        $this->symbolWhitelist = $symbolWhitelist;
+        /*
+         * Make sure the language types (e.g. 'true', 'false', 'object', 'mixed') are always included in the symbol
+         * whitelist. If these are omitted the results can be pretty unexpected.
+         */
+        $this->symbolWhitelist = array_unique(array_merge(
+            self::PHP_LANGUAGE_TYPES,
+            $symbolWhitelist
+        ));
     }
 
     /**

--- a/test/ComposerRequireCheckerTest/Cli/OptionsTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/OptionsTest.php
@@ -28,7 +28,27 @@ final class OptionsTest extends TestCase
             'symbol-whitelist' => ['foo', 'bar'],
         ]);
 
-        $this->assertSame(['foo', 'bar'], $options->getSymbolWhitelist());
+        $this->assertSame([
+            'null',
+            'true',
+            'false',
+            'static',
+            'self',
+            'parent',
+            'array',
+            'string',
+            'int',
+            'float',
+            'bool',
+            'iterable',
+            'callable',
+            'void',
+            'object',
+            'mixed',
+            'never',
+            'foo',
+            'bar',
+        ], $options->getSymbolWhitelist());
     }
 
     public function testOptionsFileRepresentsDefaults(): void
@@ -62,7 +82,28 @@ final class OptionsTest extends TestCase
         $options->setScanFiles(['one', 'two', 'three']);
         $options->setPhpCoreExtensions(['ext-one', 'ext-two']);
 
-        self::assertSame(['foo', 'bar'], $options->getSymbolWhitelist());
+        $this->assertSame([
+            'null',
+            'true',
+            'false',
+            'static',
+            'self',
+            'parent',
+            'array',
+            'string',
+            'int',
+            'float',
+            'bool',
+            'iterable',
+            'callable',
+            'void',
+            'object',
+            'mixed',
+            'never',
+            'foo',
+            'bar',
+        ], $options->getSymbolWhitelist());
+
         self::assertSame(['one', 'two', 'three'], $options->getScanFiles());
         self::assertSame(['ext-one', 'ext-two'], $options->getPhpCoreExtensions());
     }

--- a/test/ComposerRequireCheckerTest/Cli/OptionsTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/OptionsTest.php
@@ -22,10 +22,10 @@ final class OptionsTest extends TestCase
         $this->assertSame(['something'], $options->getPhpCoreExtensions());
     }
 
-    public function testOptionsAcceptSymbolWhitelist(): void
+    public function testOptionsAcceptSymbolWhitelistAndFiltersDuplicates(): void
     {
         $options = new Options([
-            'symbol-whitelist' => ['foo', 'bar'],
+            'symbol-whitelist' => ['foo', 'bar', 'null'],
         ]);
 
         $this->assertSame([


### PR DESCRIPTION
The language types should always be in the whitelist. Else, ComposerRequireChecker will give errors like:
```
The following 1 unknown symbols were found:
+----------------+--------------------+
| Unknown Symbol | Guessed Dependency |
+----------------+--------------------+
| mixed          |                    |
+----------------+--------------------+
Command exited with non-zero status 1
```