### PR TITLE
Make tests compatible with PHPUnit version 9.6.2

### DIFF
--- a/test/ComposerRequireCheckerTest/DependencyGuesser/DependencyGuesserTest.php
+++ b/test/ComposerRequireCheckerTest/DependencyGuesser/DependencyGuesserTest.php
@@ -9,6 +9,7 @@ use ComposerRequireChecker\DependencyGuesser\DependencyGuesser;
 use PHPUnit\Framework\TestCase;
 
 use function extension_loaded;
+use function iterator_to_array;
 
 final class DependencyGuesserTest extends TestCase
 {

--- a/test/ComposerRequireCheckerTest/DependencyGuesser/DependencyGuesserTest.php
+++ b/test/ComposerRequireCheckerTest/DependencyGuesser/DependencyGuesserTest.php
@@ -25,7 +25,7 @@ final class DependencyGuesserTest extends TestCase
             $this->markTestSkipped('extension json is not available');
         }
 
-        $result = $this->guesser->__invoke('json_decode');
+        $result = iterator_to_array($this->guesser->__invoke('json_decode'));
         $this->assertNotEmpty($result);
         $this->assertContains('ext-json', $result);
     }
@@ -40,7 +40,7 @@ final class DependencyGuesserTest extends TestCase
     {
         $options       = new Options(['php-core-extensions' => ['SPL', 'something-else']]);
         $this->guesser = new DependencyGuesser($options);
-        $result        = $this->guesser->__invoke('RecursiveDirectoryIterator');
+        $result        = iterator_to_array($this->guesser->__invoke('RecursiveDirectoryIterator'));
         $this->assertNotEmpty($result);
         $this->assertContains('php', $result);
     }


### PR DESCRIPTION
Version 9.6.2 of PHPUnit deprecates passing a generator to `assertNotEmpty()`. These two tests (`ComposerRequireCheckerTest\DependencyGuesser\DependencyGuesserTest::testGuessExtJson` and `ComposerRequireCheckerTest\DependencyGuesser\DependencyGuesserTest::testCoreExtensionsResolvesToPHP`) trigger this deprecation warning. See [the failing tests](https://github.com/maglnet/ComposerRequireChecker/actions/runs/4274407428/jobs/7441003197) in https://github.com/maglnet/ComposerRequireChecker/pull/390 as an example. See [the failing tests](https://github.com/maglnet/ComposerRequireChecker/actions/runs/4274405179/jobs/7440999419) in https://github.com/maglnet/ComposerRequireChecker/pull/388 as another example.

Upstream documentation of this deprecation:
https://github.com/sebastianbergmann/phpunit/blob/a1b9746ec7dce023b16dd0fd2fee24455cfd2ecb/ChangeLog-9.6.md
https://github.com/sebastianbergmann/phpunit/compare/9.6.1...9.6.2
https://github.com/sebastianbergmann/phpunit/issues/4618