### PR TITLE
Add `hash` to core extensions

### DIFF
--- a/data/config.dist.json
+++ b/data/config.dist.json
@@ -4,6 +4,7 @@
     "Core",
     "date",
     "json",
+    "hash",
     "pcre",
     "Phar",
     "Reflection",

--- a/src/ComposerRequireChecker/Cli/Options.php
+++ b/src/ComposerRequireChecker/Cli/Options.php
@@ -44,6 +44,7 @@ class Options
         'Core',
         'date',
         'json',
+        'hash',
         'pcre',
         'Phar',
         'Reflection',


### PR DESCRIPTION
As of PHP 7.4.0, the Hash extension is a core PHP extension, so it is always enabled.

see https://www.php.net/manual/en/hash.installation.php