### PR TITLE
Correct '@inheritDoc' tags

### DIFF
--- a/src/ComposerRequireChecker/Cli/ResultsWriter/CliJson.php
+++ b/src/ComposerRequireChecker/Cli/ResultsWriter/CliJson.php
@@ -27,9 +27,7 @@ final class CliJson implements ResultsWriter
         $this->nowCallable   = $now;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function write(array $unknownSymbols): void
     {
         $write = $this->writeCallable;

--- a/src/ComposerRequireChecker/Cli/ResultsWriter/CliJson.php
+++ b/src/ComposerRequireChecker/Cli/ResultsWriter/CliJson.php
@@ -28,7 +28,7 @@ final class CliJson implements ResultsWriter
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function write(array $unknownSymbols): void
     {

--- a/src/ComposerRequireChecker/Cli/ResultsWriter/CliText.php
+++ b/src/ComposerRequireChecker/Cli/ResultsWriter/CliText.php
@@ -27,9 +27,7 @@ final class CliText implements ResultsWriter
         $this->writeCallable = $write;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function write(array $unknownSymbols): void
     {
         if (! $unknownSymbols) {

--- a/src/ComposerRequireChecker/Cli/ResultsWriter/CliText.php
+++ b/src/ComposerRequireChecker/Cli/ResultsWriter/CliText.php
@@ -28,7 +28,7 @@ final class CliText implements ResultsWriter
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function write(array $unknownSymbols): void
     {

--- a/src/ComposerRequireChecker/NodeVisitor/DefinedSymbolCollector.php
+++ b/src/ComposerRequireChecker/NodeVisitor/DefinedSymbolCollector.php
@@ -21,9 +21,7 @@ final class DefinedSymbolCollector extends NodeVisitorAbstract
     {
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function beforeTraverse(array $nodes)
     {
         $this->definedSymbols = [];

--- a/src/ComposerRequireChecker/NodeVisitor/DefinedSymbolCollector.php
+++ b/src/ComposerRequireChecker/NodeVisitor/DefinedSymbolCollector.php
@@ -22,7 +22,7 @@ final class DefinedSymbolCollector extends NodeVisitorAbstract
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function beforeTraverse(array $nodes)
     {

--- a/src/ComposerRequireChecker/NodeVisitor/UsedSymbolCollector.php
+++ b/src/ComposerRequireChecker/NodeVisitor/UsedSymbolCollector.php
@@ -26,9 +26,7 @@ final class UsedSymbolCollector extends NodeVisitorAbstract
         return array_keys($this->collectedSymbols);
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function beforeTraverse(array $nodes)
     {
         $this->collectedSymbols = [];
@@ -36,9 +34,7 @@ final class UsedSymbolCollector extends NodeVisitorAbstract
         return parent::beforeTraverse($nodes);
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function enterNode(Node $node)
     {
         $this->recordExtendsUsage($node);

--- a/src/ComposerRequireChecker/NodeVisitor/UsedSymbolCollector.php
+++ b/src/ComposerRequireChecker/NodeVisitor/UsedSymbolCollector.php
@@ -27,7 +27,7 @@ final class UsedSymbolCollector extends NodeVisitorAbstract
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function beforeTraverse(array $nodes)
     {
@@ -37,7 +37,7 @@ final class UsedSymbolCollector extends NodeVisitorAbstract
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function enterNode(Node $node)
     {


### PR DESCRIPTION
This corrects the use of the `@inheritDoc` tag. See recent build failures in https://github.com/maglnet/ComposerRequireChecker/pull/401: https://github.com/maglnet/ComposerRequireChecker/actions/runs/4789576858/jobs/8517612060?pr=401