### PR TITLE
Make PHP core extensions always considered as available

### DIFF
--- a/data/config.dist.json
+++ b/data/config.dist.json
@@ -1,16 +1,5 @@
 {
   "symbol-whitelist" : [],
-  "php-core-extensions" : [
-    "Core",
-    "date",
-    "json",
-    "hash",
-    "pcre",
-    "Phar",
-    "Reflection",
-    "SPL",
-    "random",
-    "standard"
-  ],
+  "php-core-extensions" : [],
   "scan-files" : []
 }

--- a/src/ComposerRequireChecker/Cli/Options.php
+++ b/src/ComposerRequireChecker/Cli/Options.php
@@ -39,8 +39,7 @@ class Options
     /** @var array<string>  */
     private array $symbolWhitelist = self::PHP_LANGUAGE_TYPES;
 
-    /** @var array<string>  */
-    private array $phpCoreExtensions = [
+    private const PHP_CORE_EXTENSIONS = [
         'Core',
         'date',
         'json',
@@ -52,6 +51,9 @@ class Options
         'random',
         'standard',
     ];
+
+    /** @var array<string>  */
+    private array $phpCoreExtensions = self::PHP_CORE_EXTENSIONS;
 
     /**
      * @see https://github.com/webmozart/glob
@@ -104,7 +106,14 @@ class Options
     /** @param array<string> $phpCoreExtensions */
     public function setPhpCoreExtensions(array $phpCoreExtensions): void
     {
-        $this->phpCoreExtensions = $phpCoreExtensions;
+        /*
+         * Make sure the PHP core extensions are always included.
+         * If these are omitted the results can be pretty unexpected.
+         */
+        $this->phpCoreExtensions = array_unique(array_merge(
+            self::PHP_CORE_EXTENSIONS,
+            $phpCoreExtensions,
+        ));
     }
 
     /** @return array<string> a list of glob patterns for files that should be scanned in addition */

--- a/test/ComposerRequireCheckerTest/Cli/OptionsTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/OptionsTest.php
@@ -19,7 +19,19 @@ final class OptionsTest extends TestCase
             'php-core-extensions' => ['something'],
         ]);
 
-        $this->assertSame(['something'], $options->getPhpCoreExtensions());
+        $this->assertSame([
+            'Core',
+            'date',
+            'json',
+            'hash',
+            'pcre',
+            'Phar',
+            'Reflection',
+            'SPL',
+            'random',
+            'standard',
+            'something',
+        ], $options->getPhpCoreExtensions());
     }
 
     public function testOptionsAcceptSymbolWhitelistAndFiltersDuplicates(): void
@@ -104,7 +116,21 @@ final class OptionsTest extends TestCase
             'bar',
         ], $options->getSymbolWhitelist());
 
-        self::assertSame(['one', 'two', 'three'], $options->getScanFiles());
-        self::assertSame(['ext-one', 'ext-two'], $options->getPhpCoreExtensions());
+        $this->assertSame(['one', 'two', 'three'], $options->getScanFiles());
+
+        $this->assertSame([
+            'Core',
+            'date',
+            'json',
+            'hash',
+            'pcre',
+            'Phar',
+            'Reflection',
+            'SPL',
+            'random',
+            'standard',
+            'ext-one',
+            'ext-two',
+        ], $options->getPhpCoreExtensions());
     }
 }


### PR DESCRIPTION
I work on a project where we use `pcntl` extension. As this extension is not available on Windows, we do not added it in the `require` section of our `composer.json` file, and we consider it as optional.

To make checks pass, we declared this extension to `php-core-extensions` option in our config file. The problem is that we have to redeclare the whole list of PHP extensions that are part of its core.

Current proposal is a simple solution that does not introduce too many changes, but maybe the `php-core-extensions` list should not be editable (core extensions are not supposed to change on a given platform / PHP version, their list could probably be hardcoded), and the option should be renamed to something else (e.g. `available-php-extensions`).