### PR TITLE
Change detection of `/etc/shadow`

### DIFF
--- a/test/ComposerRequireCheckerTest/JsonLoaderTest.php
+++ b/test/ComposerRequireCheckerTest/JsonLoaderTest.php
@@ -9,7 +9,9 @@ use ComposerRequireChecker\Exception\NotReadable;
 use ComposerRequireChecker\JsonLoader;
 use PHPUnit\Framework\TestCase;
 
-use function file_exists;
+use function is_readable;
+
+use const PHP_OS_FAMILY;
 
 /** @covers \ComposerRequireChecker\JsonLoader */
 final class JsonLoaderTest extends TestCase
@@ -35,8 +37,8 @@ final class JsonLoaderTest extends TestCase
     public function testHasErrorWithUnreadableFile(): void
     {
         $path = '/etc/shadow';
-        if (! file_exists($path)) {
-            $this->markTestSkipped('This system does not have ' . $path);
+        if (PHP_OS_FAMILY !== 'Linux' || is_readable($path)) {
+            $this->markTestSkipped('This test relies on ' . $path . ' existing, but being unreadable.');
         }
 
         $this->expectException(NotReadable::class);


### PR DESCRIPTION
This is a work-around for `file_exists()` not working when infection/include-interceptor is loaded.

https://github.com/infection/include-interceptor/blob/afdc4767617594ba745067505573b4bb358e1e14/src/IncludeInterceptor.php#L385
This calls `is_readable()`, but we specifically need a file which exists (hence calling `file_exists()`), but is not readable. This change works around this limitation in the `infection` framework/tooling. Ideally we'd find a file which is known to exist and be unreadable on each `PHP_OS_FAMILY` to make the tests more portable.

This should squash the last mutant being reported in https://github.com/maglnet/ComposerRequireChecker/pull/388.