### PR TITLE
Remove `DIRECTORY_SEPARATOR` replacement in regular expression

### DIFF
--- a/src/ComposerRequireChecker/FileLocator/LocateAllFilesByExtension.php
+++ b/src/ComposerRequireChecker/FileLocator/LocateAllFilesByExtension.php
@@ -12,7 +12,6 @@ use Traversable;
 use function implode;
 use function preg_match;
 use function preg_quote;
-use function preg_replace;
 use function str_replace;
 use function trim;
 
@@ -82,7 +81,6 @@ final class LocateAllFilesByExtension
             $path = str_replace('/', DIRECTORY_SEPARATOR, $path);
             $path = trim($path, DIRECTORY_SEPARATOR);
             $path = preg_quote($path, '{}');
-            $path = preg_replace('{' . $dirSep . '+}', DIRECTORY_SEPARATOR, $path);
             $path = str_replace('\\*\\*', '.+?', $path);
             $path = str_replace('\\*', '[^' . $dirSep . ']+?', $path);
         }

--- a/src/ComposerRequireChecker/FileLocator/LocateAllFilesByExtension.php
+++ b/src/ComposerRequireChecker/FileLocator/LocateAllFilesByExtension.php
@@ -79,14 +79,10 @@ final class LocateAllFilesByExtension
         $dirSep = preg_quote(DIRECTORY_SEPARATOR, '{}');
 
         foreach ($blacklistPaths as &$path) {
-            $path = preg_replace(
-                '{' . $dirSep . '+}',
-                DIRECTORY_SEPARATOR,
-                preg_quote(
-                    trim(str_replace('/', DIRECTORY_SEPARATOR, $path), DIRECTORY_SEPARATOR),
-                    '{}',
-                ),
-            );
+            $path = str_replace('/', DIRECTORY_SEPARATOR, $path);
+            $path = trim($path, DIRECTORY_SEPARATOR);
+            $path = preg_quote($path, '{}');
+            $path = preg_replace('{' . $dirSep . '+}', DIRECTORY_SEPARATOR, $path);
             $path = str_replace('\\*\\*', '.+?', $path);
             $path = str_replace('\\*', '[^' . $dirSep . ']+?', $path);
         }


### PR DESCRIPTION
Fixes #416

This change doesn't break any existing tests, including mutations.