### PR TITLE
Allow specifying a relative file via phar, assert that the requested file exists

### DIFF
--- a/test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php
@@ -279,12 +279,40 @@ JSON
         );
     }
 
+    /** This is the same as the next test, but with the default configuration file assumed */
     public function testDefaultConfigPath(): void
     {
         $baseDirectory = dirname(__DIR__, 2) . '/fixtures/defaultConfigPath/';
 
         chdir($baseDirectory);
         $exitCode = $this->commandTester->execute(['composer-json' => 'composer.json']);
+        $output   = $this->commandTester->getDisplay();
+
+        $this->assertNotEquals(0, $exitCode);
+        $this->assertMatchesRegularExpression(
+            '/The following 2 unknown symbols were found/s',
+            $output,
+        );
+        $this->assertMatchesRegularExpression(
+            '/Composer\\\\InstalledVersions/s',
+            $output,
+        );
+        $this->assertMatchesRegularExpression(
+            '/json_decode/s',
+            $output,
+        );
+    }
+
+    /** This is the same as the previous test, but with the configuration file specified */
+    public function testDefaultConfigPathSpecified(): void
+    {
+        $baseDirectory = dirname(__DIR__, 2) . '/fixtures/defaultConfigPath/';
+
+        chdir($baseDirectory);
+        $exitCode = $this->commandTester->execute([
+            'composer-json' => 'composer.json',
+            '--config-file' => 'composer-require-checker.json',
+        ]);
         $output   = $this->commandTester->getDisplay();
 
         $this->assertNotEquals(0, $exitCode);
@@ -346,6 +374,20 @@ JSON
         $this->commandTester->execute([
             'composer-json' => 'composer.json',
             '--config-file' => 'not-existent-config.json',
+        ]);
+    }
+
+    public function testNotExistentDefaultConfigPath(): void
+    {
+        $baseDirectory = dirname(__DIR__, 2) . '/fixtures/noUnknownSymbols/';
+
+        chdir($baseDirectory);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Configuration file [composer-require-checker.json] does not exist.');
+        $this->commandTester->execute([
+            'composer-json' => 'composer.json',
+            '--config-file' => 'composer-require-checker.json',
         ]);
     }
 

--- a/test/ComposerRequireCheckerTest/PharTest.php
+++ b/test/ComposerRequireCheckerTest/PharTest.php
@@ -93,4 +93,13 @@ final class PharTest extends TestCase
         $this->assertStringContainsString('Configuration file [no-such-file] does not exist.', implode("\n", $output));
         $this->assertNotEquals(0, $return);
     }
+
+    public function testMissingDefaultConfiguration(): void
+    {
+        chdir(__DIR__ . '/../fixtures/noUnknownComposerSymbol');
+        exec(sprintf('%s check --config-file=%s 2>&1', $this->bin, 'composer-require-checker.json'), $output, $return);
+
+        $this->assertStringContainsString('Configuration file [composer-require-checker.json] does not exist.', implode("\n", $output));
+        $this->assertNotEquals(0, $return);
+    }
 }


### PR DESCRIPTION
There are two main changes in this pull request:
1. Relative paths now work both via Composer installation and when using the phar file. This fixes #140.
1. The file provided by the `--config-file` argument must exist. Previously when the argument was the same as the default, then missing files would be silently ignored. This fixes #507.