### PR TITLE
Replace VFS Stream with spatie temp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /phpmd.xml
 /phpunit.xml
 /.phpcs-cache
+/.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,11 @@
     "require-dev": {
         "ext-zend-opcache": "*",
         "doctrine/coding-standard": "^12.0.0",
-        "mikey179/vfsstream": "^1.6.11",
         "phing/phing": "^2.17.4",
         "phpstan/phpstan": "^1.10.59",
         "phpunit/phpunit": "^10.5.11",
         "roave/infection-static-analysis-plugin": "^1.34.0",
+        "spatie/temporary-directory": "^2.2",
         "vimeo/psalm": "^5.22.2"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7723b17d9d7f30a72e31522b0f4925fb",
+    "content-hash": "9e5d15a420c86066c3ffc6b89c2c19c3",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -2036,57 +2036,6 @@
                 "source": "https://github.com/justinrainbow/json-schema/tree/v5.2.13"
             },
             "time": "2023-09-26T02:20:38+00:00"
-        },
-        {
-            "name": "mikey179/vfsstream",
-            "version": "v1.6.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/bovigo/vfsStream.git",
-                "reference": "17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f",
-                "reference": "17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.5|^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.6.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "org\\bovigo\\vfs\\": "src/main/php"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Frank Kleine",
-                    "homepage": "http://frankkleine.de/",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Virtual file system to mock the real file system in unit tests.",
-            "homepage": "http://vfs.bovigo.org/",
-            "support": {
-                "issues": "https://github.com/bovigo/vfsStream/issues",
-                "source": "https://github.com/bovigo/vfsStream/tree/master",
-                "wiki": "https://github.com/bovigo/vfsStream/wiki"
-            },
-            "time": "2022-02-23T02:02:42+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4478,6 +4427,67 @@
                 }
             ],
             "time": "2024-02-07T10:39:02+00:00"
+        },
+        {
+            "name": "spatie/temporary-directory",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/temporary-directory.git",
+                "reference": "76949fa18f8e1a7f663fd2eaa1d00e0bcea0752a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/76949fa18f8e1a7f663fd2eaa1d00e0bcea0752a",
+                "reference": "76949fa18f8e1a7f663fd2eaa1d00e0bcea0752a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TemporaryDirectory\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily create, use and destroy temporary directories",
+            "homepage": "https://github.com/spatie/temporary-directory",
+            "keywords": [
+                "php",
+                "spatie",
+                "temporary-directory"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/temporary-directory/issues",
+                "source": "https://github.com/spatie/temporary-directory/tree/2.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-25T11:46:58+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/test/ComposerRequireCheckerTest/PharTest.php
+++ b/test/ComposerRequireCheckerTest/PharTest.php
@@ -62,7 +62,7 @@ final class PharTest extends TestCase
     {
         $path = __DIR__ . '/../fixtures/unknownSymbols/composer.json';
         exec(sprintf('%s check %s 2>&1', $this->bin, $path), $output, $return);
-        $this->assertStringContainsString('The following 6 unknown symbols were found', implode("\n", $output));
+        $this->assertStringContainsString('The following 7 unknown symbols were found', implode("\n", $output));
         $this->assertNotEquals(0, $return);
     }
 


### PR DESCRIPTION
I encountered an incompatibility with the test-suite, where real files weren't being used to run the tests. This works fine most of the time, but this is not compatible with the changes in #511. I've put these changes in a separate pull request so they can be evaluated separately from #511. There should be no changes to functionality nor test coverage with this pull request.