### PR TITLE
Add tests for Phar file

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -65,5 +65,12 @@ jobs:
               if: ${{ matrix.dependencies == 'locked' }}
               run: "composer install --no-interaction --no-progress --no-suggest"
 
+            - name: "Compile PHAR"
+              run: |
+                php -d phar.readonly=0 vendor/bin/phing phar-build
+                # We re-run 'composer install' here as phing runs 'composer install --no-dev'.
+                # Using 'install' (not 'update' with flags) here is correct as the previous update re-wrote wrote the lock file.
+                composer --no-interaction install --no-progress
+
             - name: "Tests"
               run: "vendor/bin/phpunit --coverage-clover=clover.xml --coverage-text"

--- a/test/ComposerRequireCheckerTest/PharTest.php
+++ b/test/ComposerRequireCheckerTest/PharTest.php
@@ -35,16 +35,16 @@ final class PharTest extends TestCase
             if ($return !== 0) {
                 ob_end_flush();
 
-                throw new RuntimeException('Command `' . $command . '` failed with exit code ' . $return);
+                throw new RuntimeException('Command `' . $command . '` failed with exit code ' . $return . "\n" . implode("\n", $output));
             }
 
             ob_clean();
         };
         $workingDirectory = getcwd();
         chdir(dirname(__DIR__, 2));
-        $doExec('composer install');
+        $doExec('composer --no-interaction install --no-progress --no-suggest');
         $doExec(PHP_BINARY . ' -d phar.readonly=0 vendor/bin/phing phar-build');
-        $doExec('composer install');
+        $doExec('composer --no-interaction install --no-progress --no-suggest');
         self::$bin = PHP_BINARY . ' ' . getcwd() . DIRECTORY_SEPARATOR . 'build' . DIRECTORY_SEPARATOR . 'composer-require-checker.phar';
         chdir($workingDirectory);
     }

--- a/test/ComposerRequireCheckerTest/PharTest.php
+++ b/test/ComposerRequireCheckerTest/PharTest.php
@@ -4,18 +4,15 @@ declare(strict_types=1);
 
 namespace ComposerRequireCheckerTest;
 
-use PHPUnit\Framework\Attributes\BeforeClass;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 use function chdir;
 use function dirname;
+use function escapeshellarg;
 use function exec;
 use function getcwd;
 use function implode;
-use function ob_clean;
-use function ob_end_flush;
-use function ob_start;
+use function realpath;
 use function sprintf;
 
 use const DIRECTORY_SEPARATOR;
@@ -23,35 +20,19 @@ use const PHP_BINARY;
 
 final class PharTest extends TestCase
 {
-    private static string $bin;
+    private string $bin;
     private string $oldWorkingDirectory;
-
-    #[BeforeClass]
-    public static function compilePhar(): void
-    {
-        $doExec           = static function ($command): void {
-            ob_start();
-            exec($command . ' 2>&1', $output, $return);
-            if ($return !== 0) {
-                ob_end_flush();
-
-                throw new RuntimeException('Command `' . $command . '` failed with exit code ' . $return . "\n" . implode("\n", $output));
-            }
-
-            ob_clean();
-        };
-        $workingDirectory = getcwd();
-        chdir(dirname(__DIR__, 2));
-        $doExec('composer --no-interaction install --no-progress');
-        $doExec(PHP_BINARY . ' -d phar.readonly=0 vendor/bin/phing phar-build');
-        $doExec('composer --no-interaction install --no-progress');
-        self::$bin = PHP_BINARY . ' ' . getcwd() . DIRECTORY_SEPARATOR . 'build' . DIRECTORY_SEPARATOR . 'composer-require-checker.phar';
-        chdir($workingDirectory);
-    }
 
     protected function setUp(): void
     {
+        $phar = realpath(dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'build' . DIRECTORY_SEPARATOR . 'composer-require-checker.phar');
+
+        if ($phar === false) {
+            $this->markTestSkipped('Compiled PHAR not found');
+        }
+
         $this->oldWorkingDirectory = getcwd();
+        $this->bin                 = PHP_BINARY . ' ' . escapeshellarg($phar);
     }
 
     protected function tearDown(): void
@@ -65,7 +46,7 @@ final class PharTest extends TestCase
 
     public function testVersion(): void
     {
-        $command = self::$bin . ' --version';
+        $command = $this->bin . ' --version';
         exec($command, $output, $return);
         $this->assertStringContainsString('ComposerRequireChecker', implode("\n", $output));
         $this->assertSame(0, $return);
@@ -73,14 +54,14 @@ final class PharTest extends TestCase
 
     public function testSuccess(): void
     {
-        exec(self::$bin, $output, $return);
+        exec($this->bin, $output, $return);
         $this->assertSame(0, $return);
     }
 
     public function testUnknownSymbols(): void
     {
         $path = __DIR__ . '/../fixtures/unknownSymbols/composer.json';
-        exec(sprintf('%s check %s 2>&1', self::$bin, $path), $output, $return);
+        exec(sprintf('%s check %s 2>&1', $this->bin, $path), $output, $return);
         $this->assertStringContainsString('The following 6 unknown symbols were found', implode("\n", $output));
         $this->assertNotEquals(0, $return);
     }
@@ -88,7 +69,7 @@ final class PharTest extends TestCase
     public function testInvalidConfiguration(): void
     {
         $path = __DIR__ . '/../fixtures/validJson.json';
-        exec(sprintf('%s check %s 2>&1', self::$bin, $path), $output, $return);
+        exec(sprintf('%s check %s 2>&1', $this->bin, $path), $output, $return);
         $this->assertStringContainsString('dependencies have not been installed', implode("\n", $output));
         $this->assertNotEquals(0, $return);
     }
@@ -96,7 +77,7 @@ final class PharTest extends TestCase
     public function testDefaultConfiguration(): void
     {
         chdir(__DIR__ . '/../fixtures/defaultConfigPath');
-        exec(sprintf('%s check 2>&1', self::$bin), $output, $return);
+        exec(sprintf('%s check 2>&1', $this->bin), $output, $return);
         $output = implode("\n", $output);
 
         $this->assertMatchesRegularExpression('/The following [12] unknown symbols were found/', $output);
@@ -107,7 +88,7 @@ final class PharTest extends TestCase
     public function testMissingCustomConfiguration(): void
     {
         chdir(__DIR__ . '/../fixtures/noUnknownComposerSymbol');
-        exec(sprintf('%s check --config-file=%s 2>&1', self::$bin, 'no-such-file'), $output, $return);
+        exec(sprintf('%s check --config-file=%s 2>&1', $this->bin, 'no-such-file'), $output, $return);
 
         $this->assertStringContainsString('Configuration file [no-such-file] does not exist.', implode("\n", $output));
         $this->assertNotEquals(0, $return);

--- a/test/ComposerRequireCheckerTest/PharTest.php
+++ b/test/ComposerRequireCheckerTest/PharTest.php
@@ -42,9 +42,9 @@ final class PharTest extends TestCase
         };
         $workingDirectory = getcwd();
         chdir(dirname(__DIR__, 2));
-        $doExec('composer --no-interaction install --no-progress --no-suggest');
+        $doExec('composer --no-interaction install --no-progress');
         $doExec(PHP_BINARY . ' -d phar.readonly=0 vendor/bin/phing phar-build');
-        $doExec('composer --no-interaction install --no-progress --no-suggest');
+        $doExec('composer --no-interaction install --no-progress');
         self::$bin = PHP_BINARY . ' ' . getcwd() . DIRECTORY_SEPARATOR . 'build' . DIRECTORY_SEPARATOR . 'composer-require-checker.phar';
         chdir($workingDirectory);
     }

--- a/test/ComposerRequireCheckerTest/PharTest.php
+++ b/test/ComposerRequireCheckerTest/PharTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerRequireCheckerTest;
+
+use PHPUnit\Framework\Attributes\BeforeClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function chdir;
+use function dirname;
+use function exec;
+use function getcwd;
+use function implode;
+use function ob_clean;
+use function ob_end_flush;
+use function ob_start;
+use function sprintf;
+
+use const DIRECTORY_SEPARATOR;
+use const PHP_BINARY;
+
+final class PharTest extends TestCase
+{
+    private static string $bin;
+    private string $oldWorkingDirectory;
+
+    #[BeforeClass]
+    public static function compilePhar(): void
+    {
+        $doExec           = static function ($command): void {
+            ob_start();
+            exec($command . ' 2>&1', $output, $return);
+            if ($return !== 0) {
+                ob_end_flush();
+
+                throw new RuntimeException('Command `' . $command . '` failed with exit code ' . $return);
+            }
+
+            ob_clean();
+        };
+        $workingDirectory = getcwd();
+        chdir(dirname(__DIR__, 2));
+        $doExec('composer install');
+        $doExec(PHP_BINARY . ' -d phar.readonly=0 vendor/bin/phing phar-build');
+        $doExec('composer install');
+        self::$bin = PHP_BINARY . ' ' . getcwd() . DIRECTORY_SEPARATOR . 'build' . DIRECTORY_SEPARATOR . 'composer-require-checker.phar';
+        chdir($workingDirectory);
+    }
+
+    protected function setUp(): void
+    {
+        $this->oldWorkingDirectory = getcwd();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->oldWorkingDirectory === getcwd()) {
+            return;
+        }
+
+        chdir($this->oldWorkingDirectory);
+    }
+
+    public function testVersion(): void
+    {
+        $command = self::$bin . ' --version';
+        exec($command, $output, $return);
+        $this->assertStringContainsString('ComposerRequireChecker', implode("\n", $output));
+        $this->assertSame(0, $return);
+    }
+
+    public function testSuccess(): void
+    {
+        exec(self::$bin, $output, $return);
+        $this->assertSame(0, $return);
+    }
+
+    public function testUnknownSymbols(): void
+    {
+        $path = __DIR__ . '/../fixtures/unknownSymbols/composer.json';
+        exec(sprintf('%s check %s 2>&1', self::$bin, $path), $output, $return);
+        $this->assertStringContainsString('The following 6 unknown symbols were found', implode("\n", $output));
+        $this->assertNotEquals(0, $return);
+    }
+
+    public function testInvalidConfiguration(): void
+    {
+        $path = __DIR__ . '/../fixtures/validJson.json';
+        exec(sprintf('%s check %s 2>&1', self::$bin, $path), $output, $return);
+        $this->assertStringContainsString('dependencies have not been installed', implode("\n", $output));
+        $this->assertNotEquals(0, $return);
+    }
+
+    public function testDefaultConfiguration(): void
+    {
+        chdir(__DIR__ . '/../fixtures/defaultConfigPath');
+        exec(sprintf('%s check 2>&1', self::$bin), $output, $return);
+        $output = implode("\n", $output);
+
+        $this->assertMatchesRegularExpression('/The following [12] unknown symbols were found/', $output);
+        $this->assertMatchesRegularExpression('/Composer\\\\InstalledVersions/', $output);
+        $this->assertNotEquals(0, $return);
+    }
+
+    public function testMissingCustomConfiguration(): void
+    {
+        chdir(__DIR__ . '/../fixtures/noUnknownComposerSymbol');
+        exec(sprintf('%s check --config-file=%s 2>&1', self::$bin, 'no-such-file'), $output, $return);
+
+        $this->assertStringContainsString('Configuration file [no-such-file] does not exist.', implode("\n", $output));
+        $this->assertNotEquals(0, $return);
+    }
+}


### PR DESCRIPTION
I would like to add some tests to verify the behaviour of the phar file as part of #511. However, given that the phar file seems to be currently untested, I'm adding a basic set of tests here as there are multiple approaches for this, and I don't want to pollute #511 with that discussion.

~~In this pull request, I'm using `phing` to build the phar in a `setUpBeforeClass()` method, but because that library messes with the composer installation, I'm wrapping that with `composer install`.~~

~~Another approach would be to use phing to build the phar in a GitHub Action workflow (eg, based on `.github/workflows/phar-creation.yml`), and then run some stand-alone tests written in a shell script or similar. This approach would remove the complication of having to compile a phar / use phing from within phpunit, but would mean we'd have to maintain two different testing frameworks.~~

In this pull request, I've chosen to skip the tests for the phar file if it's not found on disk, and to build the phar as part of the GitHub Actions workflow, just before we run the phpunit test suite.