### PR TITLE
[phing] Use non-deprecated XML syntax in build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -28,8 +28,12 @@
     <!-- ============================================  -->
     <target name="run-test">
         <php returnProperty="php-executable" expression="PHP_BINARY" level="debug"/>
-        <exec command="${php-executable} vendor/phpunit/phpunit/phpunit" passthru="true" checkreturn="true"/>
-        <exec command="${php-executable} bin/composer-require-checker.php" passthru="true" checkreturn="true"/>
+        <exec executable="${php-executable}" checkreturn="true" passthru="true">
+            <arg line="vendor/phpunit/phpunit/phpunit"/>
+        </exec>
+        <exec executable="${php-executable}" checkreturn="true" passthru="true">
+            <arg line="bin/composer-require-checker.php"/>
+        </exec>
     </target>
 
     <!-- ============================================  -->
@@ -37,7 +41,9 @@
     <!-- ============================================  -->
     <target name="phar-prepare-dependencies">
         <!--install dependencies without development requirements-->
-        <exec command="composer install --no-dev -o" passthru="true" checkreturn="true"/>
+        <exec executable="composer" checkreturn="true" passthru="true">
+            <arg line="--no-interaction install --no-dev --optimize-autoloader"/>
+        </exec>
     </target>
 
     <!-- ============================================  -->


### PR DESCRIPTION
While looking into the build failures in #515, I noticed that there is an upcoming major version of the phing tool. When exploring that a little further, I noticed that the current `build.xml` file has a mix of old and new syntax for the `exec` nodes. This pull request updates the syntax to be consistent with the current/new format. I didn't find an XSD to validate the XML against.

Ref: https://github.com/phingofficial/phing/issues/1252#issuecomment-582638955

I have also expanded the short flag `-o` to its long-format equivalent `--optimize-autoloader` for the `composer install` command, and added the `--no-interaction` flag.