### PR TITLE
Add export-ignore entries to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@ test export-ignore
 .gitignore export-ignore
 baseline.xml export-ignore
 build.xml export-ignore
+composer.lock export-ignore
 infection.json.dist export-ignore
 phpcs.xml.dist export-ignore
 phpstan.neon export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,14 @@
 CHANGELOG.md merge=union
+
+.github export-ignore
+test export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+baseline.xml export-ignore
+build.xml export-ignore
+infection.json.dist export-ignore
+phpcs.xml.dist export-ignore
+phpstan.neon export-ignore
+phpunit.xml.dist export-ignore
+psalm.xml export-ignore
+renovate.json export-ignore


### PR DESCRIPTION
Hi @Ocramius,

Seems like there is no `export-ignore` directive in this repo.
I tried to add some.