### PR TITLE
Fix Psalm complaint in `LocateDefinedSymbolsFromComposerRuntimeApiTest`

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.22.2@d768d914152dbbf3486c36398802f74e80cfde48">
+<files psalm-version="5.23.1@8471a896ccea3526b26d082f4461eeea467f10a4">
   <file src="src/ComposerRequireChecker/Cli/CheckCommand.php">
     <MixedArgumentTypeCoercion>
       <code><![CDATA[(new ComposeGenerators())->__invoke(
@@ -59,10 +59,6 @@
       <code><![CDATA[json_decode($composerJson, true)]]></code>
       <code><![CDATA[json_decode($composerJson, true)]]></code>
     </MixedArgument>
-    <MixedInferredReturnType>
-      <code><![CDATA[Generator]]></code>
-      <code><![CDATA[Generator]]></code>
-    </MixedInferredReturnType>
   </file>
   <file src="test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromExtensionsTest.php">
     <ArgumentTypeCoercion>

--- a/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromComposerRuntimeApiTest.php
+++ b/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromComposerRuntimeApiTest.php
@@ -39,20 +39,20 @@ class LocateDefinedSymbolsFromComposerRuntimeApiTest extends TestCase
 
     public static function provideComposerJsonWithUnsuitableComposerRuntimeApi(): Generator
     {
-        yield ['{ "require": { "composer-runtime-api": "^1.0" } }'];
-        yield ['{ "require": { "composer-runtime-api": "^1" } }'];
-        yield ['{ "require": { "composer-runtime-api": "~1" } }'];
-        yield ['{ "require": { "composer-runtime-api": "=1" } }'];
+        yield 'Caret major minor' => ['composerJson' => '{ "require": { "composer-runtime-api": "^1.0" } }'];
+        yield 'Caret major' => ['composerJson' => '{ "require": { "composer-runtime-api": "^1" } }'];
+        yield 'Tilde major' => ['composerJson' => '{ "require": { "composer-runtime-api": "~1" } }'];
+        yield 'Equal major' => ['composerJson' => '{ "require": { "composer-runtime-api": "=1" } }'];
     }
 
     public static function provideComposerJsonWithSuitableComposerRuntimeApi(): Generator
     {
-        yield ['{ "require": { "composer-runtime-api": "^2.0" } }'];
-        yield ['{ "require": { "composer-runtime-api": "^2" } }'];
-        yield ['{ "require": { "composer-runtime-api": "~2" } }'];
-        yield ['{ "require": { "composer-runtime-api": ">=2" } }'];
-        yield ['{ "require": { "composer-runtime-api": "=2" } }'];
-        yield ['{ "require": { "composer-runtime-api": ">2" } }'];
+        yield 'Caret major minor' => ['composerJson' => '{ "require": { "composer-runtime-api": "^2.0" } }'];
+        yield 'Caret major' => ['composerJson' => '{ "require": { "composer-runtime-api": "^2" } }'];
+        yield 'Tilde major' => ['composerJson' => '{ "require": { "composer-runtime-api": "~2" } }'];
+        yield 'Greater equal major' => ['composerJson' => '{ "require": { "composer-runtime-api": ">=2" } }'];
+        yield 'Equal major' => ['composerJson' => '{ "require": { "composer-runtime-api": "=2" } }'];
+        yield 'Greater major' => ['composerJson' => '{ "require": { "composer-runtime-api": ">2" } }'];
     }
 
     /**

--- a/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromComposerRuntimeApiTest.php
+++ b/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromComposerRuntimeApiTest.php
@@ -37,6 +37,7 @@ class LocateDefinedSymbolsFromComposerRuntimeApiTest extends TestCase
         self::assertContains('Composer\InstalledVersions', $symbols);
     }
 
+    /** @return Generator<array-key, array<array-key, string>> */
     public static function provideComposerJsonWithUnsuitableComposerRuntimeApi(): Generator
     {
         yield 'Caret major minor' => ['composerJson' => '{ "require": { "composer-runtime-api": "^1.0" } }'];
@@ -45,6 +46,7 @@ class LocateDefinedSymbolsFromComposerRuntimeApiTest extends TestCase
         yield 'Equal major' => ['composerJson' => '{ "require": { "composer-runtime-api": "=1" } }'];
     }
 
+    /** @return Generator<array-key, array<array-key, string>> */
     public static function provideComposerJsonWithSuitableComposerRuntimeApi(): Generator
     {
         yield 'Caret major minor' => ['composerJson' => '{ "require": { "composer-runtime-api": "^2.0" } }'];


### PR DESCRIPTION
These changes (specifically 5245abe3d8a24a5d5090e5fe81cc7b42d2e07718) should make the test suite pass in #537. From what I can tell, a particular complaint has been renamed in Psalm, so the existing baseline entry doesn't match this any more and the tests therefore fail. This pull request fixes the underlying issue, which means that the baseline should match over there without any difficulty any more.