### PR TITLE
Add missing comma for function call with arrow function as argument

### DIFF
--- a/src/ComposerRequireChecker/Cli/CheckCommand.php
+++ b/src/ComposerRequireChecker/Cli/CheckCommand.php
@@ -195,7 +195,7 @@ class CheckCommand extends Command
                 $resultsWriter = new CliJson(
                     $outputWrapper,
                     $application?->getVersion() ?? 'Unknown version',
-                    static fn () => new DateTimeImmutable()
+                    static fn () => new DateTimeImmutable(),
                 );
                 break;
             case 'text':

--- a/test/ComposerRequireCheckerTest/Cli/ResultsWriter/CliJsonTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/ResultsWriter/CliJsonTest.php
@@ -26,7 +26,7 @@ final class CliJsonTest extends TestCase
                 $this->output .= $string;
             },
             '0.0.1',
-            static fn () => new DateTimeImmutable('@0')
+            static fn () => new DateTimeImmutable('@0'),
         );
     }
 


### PR DESCRIPTION
In versions before 8.15.0 the `SlevomatCodingStandard.Functions.RequireTrailingCommaInCall` sniff had a false-negative for arrow functions. This has been [fixed in version 8.15.0 as noted in the release notes](https://github.com/slevomat/coding-standard/releases/tag/8.15.0). See https://github.com/slevomat/coding-standard/commit/8d0f603befc9dbc50735dc5cb4ef62015a6d915b for the specific commit which resolves this issue.

The change in this pull request should allow the test suite to pass for #535 where the version of the Slevomat coding standard has been increased from 8.14.1 to 8.15.0.