### PR TITLE
Add composer.lock file back to release artifact

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,6 @@ test export-ignore
 .gitignore export-ignore
 baseline.xml export-ignore
 build.xml export-ignore
-composer.lock export-ignore
 infection.json.dist export-ignore
 phpcs.xml.dist export-ignore
 phpstan.neon export-ignore


### PR DESCRIPTION
This application is meant as a standalone CLI app and therefor should have the composer lock file present in its release artifacts.

Fixes https://github.com/maglnet/ComposerRequireChecker/issues/549