### PR TITLE
Remove now-unnecessary PHP `<8.2` code

### DIFF
--- a/src/ComposerRequireChecker/DefinedSymbolsLocator/LocateDefinedSymbolsFromExtensions.php
+++ b/src/ComposerRequireChecker/DefinedSymbolsLocator/LocateDefinedSymbolsFromExtensions.php
@@ -11,8 +11,6 @@ use Throwable;
 use function array_keys;
 use function array_merge;
 
-use const PHP_VERSION_ID;
-
 class LocateDefinedSymbolsFromExtensions
 {
     /**
@@ -37,11 +35,6 @@ class LocateDefinedSymbolsFromExtensions
         $definedSymbols = [];
         foreach ($extensionNames as $extensionName) {
             $extensionName = self::ALTERNATIVES[$extensionName] ?? $extensionName;
-
-            // @infection-ignore-all LessThan No point in testing this on 8.2.0 specifically
-            if ($extensionName === 'random' && PHP_VERSION_ID < 80200) {
-                continue;
-            }
 
             try {
                 $extensionReflection = new ReflectionExtension($extensionName);

--- a/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromExtensionsTest.php
+++ b/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromExtensionsTest.php
@@ -11,8 +11,6 @@ use function array_merge;
 use function count;
 use function in_array;
 
-use const PHP_VERSION_ID;
-
 final class LocateDefinedSymbolsFromExtensionsTest extends TestCase
 {
     private LocateDefinedSymbolsFromExtensions $locator;
@@ -72,35 +70,9 @@ final class LocateDefinedSymbolsFromExtensionsTest extends TestCase
         $this->assertSame(array_merge($coreSymbols, $standardSymbols), $combinedSymbols);
     }
 
-    public function testDoesNotCollectAnySymbolsForTheRandomExtensionOnPhpVersionsLowerThan82(): void
-    {
-        if (PHP_VERSION_ID >= 80200) {
-            $this->markTestSkipped('This test is only relevant for PHP versions lower than 8.2');
-        }
-
-        $symbols = $this->locator->__invoke(['random']);
-
-        $this->assertEmpty($symbols);
-    }
-
     public function testCollectsSymbolsForTheRandomExtensionOnPhpVersions82AndHigher(): void
     {
-        if (PHP_VERSION_ID < 80200) {
-            $this->markTestSkipped('This test is only relevant for PHP versions 8.2 and higher');
-        }
-
         $symbols = $this->locator->__invoke(['random']);
-
-        $this->assertNotEmpty($symbols);
-    }
-
-    public function testDoesNotStopCollectingSymbolsWhenSkippingTheRandomExtension(): void
-    {
-        if (PHP_VERSION_ID >= 80200) {
-            $this->markTestSkipped('This test is only relevant for PHP versions lower than 8.2');
-        }
-
-        $symbols = $this->locator->__invoke(['random', 'Core']);
 
         $this->assertNotEmpty($symbols);
     }


### PR DESCRIPTION
I had a look at the test failures / changes in https://github.com/maglnet/ComposerRequireChecker/pull/552. It turns out that the code here can be safely removed, as we no longer support PHP versions below 8.2.0 - see https://github.com/maglnet/ComposerRequireChecker/pull/460 for that change.

This pull request fixes one of the two test failures in #552.