### PR TITLE
Remove redundant `array_filter()` calls

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.23.1@8471a896ccea3526b26d082f4461eeea467f10a4">
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
   <file src="src/ComposerRequireChecker/Cli/CheckCommand.php">
     <MixedArgumentTypeCoercion>
       <code><![CDATA[(new ComposeGenerators())->__invoke(
@@ -177,7 +177,6 @@
       <code><![CDATA[$functionName]]></code>
       <code><![CDATA[$functionName]]></code>
       <code><![CDATA['Bar']]></code>
-      <code><![CDATA[[null]]]></code>
     </InvalidPropertyAssignmentValue>
   </file>
   <file src="test/ComposerRequireCheckerTest/UsedSymbolsLocator/LocateUsedSymbolsFromASTRootsTest.php">

--- a/src/ComposerRequireChecker/NodeVisitor/UsedSymbolCollector.php
+++ b/src/ComposerRequireChecker/NodeVisitor/UsedSymbolCollector.php
@@ -7,7 +7,6 @@ namespace ComposerRequireChecker\NodeVisitor;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
-use function array_filter;
 use function array_keys;
 use function array_map;
 
@@ -54,15 +53,15 @@ final class UsedSymbolCollector extends NodeVisitorAbstract
 
     private function recordExtendsUsage(Node $node): void
     {
-        if ($node instanceof Node\Stmt\Class_) {
-            array_map([$this, 'recordUsageOf'], array_filter([$node->extends]));
+        if ($node instanceof Node\Stmt\Class_ && $node->extends !== null) {
+            $this->recordUsageOf($node->extends);
         }
 
         if (! ($node instanceof Node\Stmt\Interface_)) {
             return;
         }
 
-        array_map([$this, 'recordUsageOf'], array_filter($node->extends));
+        array_map([$this, 'recordUsageOf'], $node->extends);
     }
 
     private function recordImplementsUsage(Node $node): void

--- a/test/ComposerRequireCheckerTest/NodeVisitor/UsedSymbolCollectorTest.php
+++ b/test/ComposerRequireCheckerTest/NodeVisitor/UsedSymbolCollectorTest.php
@@ -67,8 +67,7 @@ final class UsedSymbolCollectorTest extends TestCase
 
     public function testInterfaceWithoutExtends(): void
     {
-        $node          = new Interface_('Foo');
-        $node->extends = [null];
+        $node = new Interface_('Foo', ['extends' => []]);
 
         $this->visitor->enterNode($node);
 


### PR DESCRIPTION
PHPStan v2 is reporting that `\PhpParser\Node\Stmt\Interface_->extends` cannot contain falsy values. The PHPDoc type for this property declares its type as `\PhpParser\Node\Name[]`. Therefore, `[null]` is not a valid value for this property. Taking this into account, calling `array_filter()` on the property is not necessary.

Additionally, the code for `\PhpParser\Node\Stmt\Class_->extends` can be simplified to remove the `array_map()` and `array_filter()` calls.

As a bonus, one violation in the Psalm baseline has been removed as part of this change.

Example of the error shown: https://phpstan.org/r/5949c61d-6441-4103-b5bc-3a1d43a94715

This should fix the test failure shown in #552 