### PR TITLE
Move phar build (with phing) into build directory

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -20,6 +20,15 @@
     <target name="prepare">
         <echo msg="preparing build directory"/>
         <mkdir dir="${build-dir}"/>
+        <copy todir="${build-dir}">
+            <fileset dir="./">
+                <include name="src/**/*.php" />
+                <include name="bin/*" />
+                <include name="LICENSE" />
+                <include name="composer.json" />
+                <include name="composer.lock" />
+            </fileset>
+        </copy>
     </target>
 
 
@@ -41,7 +50,7 @@
     <!-- ============================================  -->
     <target name="phar-prepare-dependencies" depends="prepare">
         <!--install dependencies without development requirements-->
-        <exec executable="composer" checkreturn="true" passthru="true">
+        <exec executable="composer" dir="${build-dir}" checkreturn="true" passthru="true">
             <arg line="--no-interaction install --no-dev --optimize-autoloader"/>
         </exec>
     </target>
@@ -62,18 +71,11 @@
         <!--create the package-->
         <mkdir dir="${build-dir}" />
         <php expression="file_put_contents('bin/clistub.php', '#!/usr/bin/env php' . chr(10) . Phar::createDefaultStub('bin/composer-require-checker.php'))"/>
-        <pharpackage basedir="./"
+        <pharpackage basedir="${build-dir}"
                      destfile="${build-dir}/${phing.project.name}.phar"
                      stub="bin/clistub.php"
                      compression="gzip">
-            <fileset dir="./">
-                <include name="src/**/*.php"/>
-                <include name="bin/*"/>
-                <include name="vendor/**"/>
-                <include name="LICENSE"/>
-                <include name="composer.json"/>
-                <include name="composer.lock"/>
-            </fileset>
+            <fileset dir="${build-dir}" />
         </pharpackage>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -9,10 +9,7 @@
 
 
 <project name="composer-require-checker" default="phar-build">
-
     <property name="build-dir" value="build"/>
-    <property name="phar-dir" value="build/phar"/>
-
 
     <!-- ============================================  -->
     <!-- Target: prepare                               -->

--- a/build.xml
+++ b/build.xml
@@ -26,7 +26,7 @@
     <!-- ============================================  -->
     <!-- Target: run-test                               -->
     <!-- ============================================  -->
-    <target name="run-test">
+    <target name="run-test" depends="prepare-dev-dependencies">
         <php returnProperty="php-executable" expression="PHP_BINARY" level="debug"/>
         <exec executable="${php-executable}" checkreturn="true" passthru="true">
             <arg line="vendor/phpunit/phpunit/phpunit"/>
@@ -39,7 +39,7 @@
     <!-- ============================================  -->
     <!-- Target: phar-prepare-dependencies             -->
     <!-- ============================================  -->
-    <target name="phar-prepare-dependencies">
+    <target name="phar-prepare-dependencies" depends="prepare">
         <!--install dependencies without development requirements-->
         <exec executable="composer" checkreturn="true" passthru="true">
             <arg line="--no-interaction install --no-dev --optimize-autoloader"/>
@@ -74,11 +74,10 @@
                 <include name="composer.json"/>
                 <include name="composer.lock"/>
             </fileset>
-
         </pharpackage>
     </target>
 
-    <target name="phar-sign">
+    <target name="phar-sign" depends="phar-build">
         <delete file="${build-dir}/${phing.project.name}.phar.asc"/>
         <exec executable="gpg" checkreturn="true" passthru="true">
             <arg value="--batch" />


### PR DESCRIPTION
Phing recommends building a phar in a different directory to where phing is installed. See https://github.com/phingofficial/phing/issues/1891#issuecomment-2566514841

This should fix the test failure in #540.