### PR TITLE
Fix Phar release action

### DIFF
--- a/.github/workflows/phar-creation.yml
+++ b/.github/workflows/phar-creation.yml
@@ -32,7 +32,7 @@ jobs:
               run: "composer install --no-interaction --no-progress --no-suggest"
 
             - name: "Build and sign phar file via phing"
-              run: "vendor/bin/phing phar-build phar-sign"
+              run: "vendor/bin/phing phar-build-release"
 
             - name: "Upload phar file artifact"
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
Could fix #565; using the different call for the build seems to work for my local environment except for the sign step (as I do not have the key obviously).