### PR TITLE
Supress ClassMustBeFinal in Psalm results

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -16,8 +16,12 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
-    
+
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+
+    <issueHandlers>
+        <ClassMustBeFinal errorLevel="suppress" />
+    </issueHandlers>
 </psalm>


### PR DESCRIPTION
A new rule (ClassMustBeFinal) has been introduced in Psalm v6.6.0. These classes are being identified as candidates for being marked as final.

This should fix the test failures in https://github.com/maglnet/ComposerRequireChecker/pull/570