### PR TITLE
Mark overriden methods with #[\Override] attribute

### DIFF
--- a/src/ComposerRequireChecker/Cli/CheckCommand.php
+++ b/src/ComposerRequireChecker/Cli/CheckCommand.php
@@ -23,6 +23,7 @@ use ComposerRequireChecker\UsedSymbolsLocator\LocateUsedSymbolsFromASTRoots;
 use DateTimeImmutable;
 use InvalidArgumentException;
 use LogicException;
+use Override;
 use PhpParser\ErrorHandler\Collecting as CollectingErrorHandler;
 use PhpParser\ParserFactory;
 use Symfony\Component\Console\Command\Command;
@@ -50,6 +51,7 @@ class CheckCommand extends Command
     public const NAME                 = 'check';
     private const DEFAULT_CONFIG_PATH = 'composer-require-checker.json';
 
+    #[Override]
     protected function configure(): void
     {
         $this
@@ -82,6 +84,7 @@ class CheckCommand extends Command
             );
     }
 
+    #[Override]
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         if ($input->getOption('output') === null) {
@@ -98,6 +101,7 @@ class CheckCommand extends Command
         }
     }
 
+    #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getOption('output') !== null) {

--- a/src/ComposerRequireChecker/Cli/ResultsWriter/CliJson.php
+++ b/src/ComposerRequireChecker/Cli/ResultsWriter/CliJson.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ComposerRequireChecker\Cli\ResultsWriter;
 
 use DateTimeImmutable;
+use Override;
 
 use function json_encode;
 
@@ -28,6 +29,7 @@ final class CliJson implements ResultsWriter
     }
 
     /** @inheritDoc */
+    #[Override]
     public function write(array $unknownSymbols): void
     {
         $write = $this->writeCallable;

--- a/src/ComposerRequireChecker/Cli/ResultsWriter/CliText.php
+++ b/src/ComposerRequireChecker/Cli/ResultsWriter/CliText.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ComposerRequireChecker\Cli\ResultsWriter;
 
+use Override;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -28,6 +29,7 @@ final class CliText implements ResultsWriter
     }
 
     /** @inheritDoc */
+    #[Override]
     public function write(array $unknownSymbols): void
     {
         if (! $unknownSymbols) {

--- a/src/ComposerRequireChecker/DependencyGuesser/GuessFromLoadedExtensions.php
+++ b/src/ComposerRequireChecker/DependencyGuesser/GuessFromLoadedExtensions.php
@@ -7,6 +7,7 @@ namespace ComposerRequireChecker\DependencyGuesser;
 use ComposerRequireChecker\Cli\Options;
 use ComposerRequireChecker\DefinedSymbolsLocator\LocateDefinedSymbolsFromExtensions;
 use Generator;
+use Override;
 
 use function get_loaded_extensions;
 use function in_array;
@@ -30,6 +31,7 @@ class GuessFromLoadedExtensions implements Guesser
     }
 
     /** @return Generator<string> */
+    #[Override]
     public function __invoke(string $symbolName): Generator
     {
         $definedSymbolsFromExtensions = new LocateDefinedSymbolsFromExtensions();

--- a/src/ComposerRequireChecker/NodeVisitor/DefinedSymbolCollector.php
+++ b/src/ComposerRequireChecker/NodeVisitor/DefinedSymbolCollector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ComposerRequireChecker\NodeVisitor;
 
+use Override;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 use ReflectionProperty;
@@ -22,6 +23,7 @@ final class DefinedSymbolCollector extends NodeVisitorAbstract
     }
 
     /** @inheritDoc */
+    #[Override]
     public function beforeTraverse(array $nodes)
     {
         $this->definedSymbols = [];
@@ -35,6 +37,7 @@ final class DefinedSymbolCollector extends NodeVisitorAbstract
         return array_keys($this->definedSymbols);
     }
 
+    #[Override]
     public function enterNode(Node $node): Node
     {
         $this->recordClassDefinition($node);

--- a/src/ComposerRequireChecker/NodeVisitor/UsedSymbolCollector.php
+++ b/src/ComposerRequireChecker/NodeVisitor/UsedSymbolCollector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ComposerRequireChecker\NodeVisitor;
 
+use Override;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
@@ -26,6 +27,7 @@ final class UsedSymbolCollector extends NodeVisitorAbstract
     }
 
     /** @inheritDoc */
+    #[Override]
     public function beforeTraverse(array $nodes)
     {
         $this->collectedSymbols = [];
@@ -34,6 +36,7 @@ final class UsedSymbolCollector extends NodeVisitorAbstract
     }
 
     /** @inheritDoc */
+    #[Override]
     public function enterNode(Node $node)
     {
         $this->recordExtendsUsage($node);

--- a/test/ComposerRequireCheckerTest/ASTLocator/LocateASTFromFilesTest.php
+++ b/test/ComposerRequireCheckerTest/ASTLocator/LocateASTFromFilesTest.php
@@ -7,6 +7,7 @@ namespace ComposerRequireCheckerTest\ASTLocator;
 use ArrayObject;
 use ComposerRequireChecker\ASTLocator\LocateASTFromFiles;
 use ComposerRequireChecker\Exception\FileParseFailed;
+use Override;
 use PhpParser\ErrorHandler\Collecting;
 use PhpParser\Lexer;
 use PhpParser\Node\Stmt;
@@ -24,6 +25,7 @@ final class LocateASTFromFilesTest extends TestCase
     private LocateASTFromFiles $locator;
     private TemporaryDirectory $root;
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/test/ComposerRequireCheckerTest/BinaryTest.php
+++ b/test/ComposerRequireCheckerTest/BinaryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ComposerRequireCheckerTest;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 
 use function exec;
@@ -17,6 +18,7 @@ final class BinaryTest extends TestCase
 {
     private string $bin;
 
+    #[Override]
     protected function setUp(): void
     {
         if (strpos(PHP_OS, 'WIN') === 0) {

--- a/test/ComposerRequireCheckerTest/Cli/ApplicationTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/ApplicationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ComposerRequireCheckerTest\Cli;
 
 use ComposerRequireChecker\Cli\Application;
+use Override;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 
@@ -12,6 +13,7 @@ final class ApplicationTest extends TestCase
 {
     private Application $application;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->application = new Application();

--- a/test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php
@@ -7,6 +7,7 @@ namespace ComposerRequireCheckerTest\Cli;
 use ComposerRequireChecker\Cli\Application;
 use InvalidArgumentException;
 use LogicException;
+use Override;
 use PHPUnit\Framework\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Symfony\Component\Console\Command\Command;
@@ -28,6 +29,7 @@ final class CheckCommandTest extends TestCase
 {
     private CommandTester $commandTester;
 
+    #[Override]
     protected function setUp(): void
     {
         $application = new Application();

--- a/test/ComposerRequireCheckerTest/Cli/ResultsWriter/CliJsonTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/ResultsWriter/CliJsonTest.php
@@ -6,6 +6,7 @@ namespace ComposerRequireCheckerTest\Cli\ResultsWriter;
 
 use ComposerRequireChecker\Cli\ResultsWriter\CliJson;
 use DateTimeImmutable;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 use function json_decode;
@@ -17,6 +18,7 @@ final class CliJsonTest extends TestCase
     private CliJson $writer;
     private string $output = '';
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/test/ComposerRequireCheckerTest/Cli/ResultsWriter/CliTextTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/ResultsWriter/CliTextTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ComposerRequireCheckerTest\Cli\ResultsWriter;
 
 use ComposerRequireChecker\Cli\ResultsWriter\CliText;
+use Override;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,6 +17,7 @@ final class CliTextTest extends TestCase
     private CliText $writer;
     private BufferedOutput $output;
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/test/ComposerRequireCheckerTest/DefinedExtensionsResolver/DefinedExtensionsResolverTest.php
+++ b/test/ComposerRequireCheckerTest/DefinedExtensionsResolver/DefinedExtensionsResolverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ComposerRequireCheckerTest\DefinedExtensionsResolver;
 
 use ComposerRequireChecker\DefinedExtensionsResolver\DefinedExtensionsResolver;
+use Override;
 use PHPUnit\Framework\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
@@ -16,6 +17,7 @@ final class DefinedExtensionsResolverTest extends TestCase
     private DefinedExtensionsResolver $resolver;
     private TemporaryDirectory $root;
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromASTRootsTest.php
+++ b/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromASTRootsTest.php
@@ -6,6 +6,7 @@ namespace ComposerRequireCheckerTest\DefinedSymbolsLocator;
 
 use ArrayObject;
 use ComposerRequireChecker\DefinedSymbolsLocator\LocateDefinedSymbolsFromASTRoots;
+use Override;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
@@ -21,6 +22,7 @@ final class LocateDefinedSymbolsFromASTRootsTest extends TestCase
 {
     private LocateDefinedSymbolsFromASTRoots $locator;
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromComposerRuntimeApiTest.php
+++ b/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromComposerRuntimeApiTest.php
@@ -6,6 +6,7 @@ namespace ComposerRequireCheckerTest\DefinedSymbolsLocator;
 
 use ComposerRequireChecker\DefinedSymbolsLocator\LocateDefinedSymbolsFromComposerRuntimeApi;
 use Generator;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 use function json_decode;
@@ -14,6 +15,7 @@ class LocateDefinedSymbolsFromComposerRuntimeApiTest extends TestCase
 {
     private LocateDefinedSymbolsFromComposerRuntimeApi $locator;
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromExtensionsTest.php
+++ b/test/ComposerRequireCheckerTest/DefinedSymbolsLocator/LocateDefinedSymbolsFromExtensionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ComposerRequireCheckerTest\DefinedSymbolsLocator;
 
 use ComposerRequireChecker\DefinedSymbolsLocator\LocateDefinedSymbolsFromExtensions;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 use function array_merge;
@@ -15,6 +16,7 @@ final class LocateDefinedSymbolsFromExtensionsTest extends TestCase
 {
     private LocateDefinedSymbolsFromExtensions $locator;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->locator = new LocateDefinedSymbolsFromExtensions();

--- a/test/ComposerRequireCheckerTest/DependencyGuesser/DependencyGuesserTest.php
+++ b/test/ComposerRequireCheckerTest/DependencyGuesser/DependencyGuesserTest.php
@@ -6,6 +6,7 @@ namespace ComposerRequireCheckerTest\DependencyGuesser;
 
 use ComposerRequireChecker\Cli\Options;
 use ComposerRequireChecker\DependencyGuesser\DependencyGuesser;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 use function extension_loaded;
@@ -15,6 +16,7 @@ final class DependencyGuesserTest extends TestCase
 {
     private DependencyGuesser $guesser;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->guesser = new DependencyGuesser();

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateAllFilesByExtensionTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateAllFilesByExtensionTest.php
@@ -6,6 +6,7 @@ namespace ComposerRequireCheckerTest\FileLocator;
 
 use ArrayObject;
 use ComposerRequireChecker\FileLocator\LocateAllFilesByExtension;
+use Override;
 use PHPUnit\Framework\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
@@ -23,6 +24,7 @@ final class LocateAllFilesByExtensionTest extends TestCase
     private LocateAllFilesByExtension $locator;
     private TemporaryDirectory $root;
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageDirectDependenciesSourceFilesTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageDirectDependenciesSourceFilesTest.php
@@ -6,6 +6,7 @@ namespace ComposerRequireCheckerTest\FileLocator;
 
 use ComposerRequireChecker\Exception\DependenciesNotInstalled;
 use ComposerRequireChecker\FileLocator\LocateComposerPackageDirectDependenciesSourceFiles;
+use Override;
 use PHPUnit\Framework\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
@@ -23,6 +24,7 @@ final class LocateComposerPackageDirectDependenciesSourceFilesTest extends TestC
     private LocateComposerPackageDirectDependenciesSourceFiles $locator;
     private TemporaryDirectory $root;
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageSourceFilesTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageSourceFilesTest.php
@@ -6,6 +6,7 @@ namespace ComposerRequireCheckerTest\FileLocator;
 
 use ComposerRequireChecker\FileLocator\LocateComposerPackageSourceFiles;
 use ComposerRequireChecker\JsonLoader;
+use Override;
 use PHPUnit\Framework\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
@@ -25,6 +26,7 @@ final class LocateComposerPackageSourceFilesTest extends TestCase
     private LocateComposerPackageSourceFiles $locator;
     private TemporaryDirectory $root;
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateFilesByGlobPatternTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateFilesByGlobPatternTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ComposerRequireCheckerTest\FileLocator;
 
 use ComposerRequireChecker\FileLocator\LocateFilesByGlobPattern;
+use Override;
 use PHPUnit\Framework\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
@@ -21,6 +22,7 @@ final class LocateFilesByGlobPatternTest extends TestCase
 
     private TemporaryDirectory $root;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->locator = new LocateFilesByGlobPattern();

--- a/test/ComposerRequireCheckerTest/NodeVisitor/DefinedSymbolCollectorFunctionalTest.php
+++ b/test/ComposerRequireCheckerTest/NodeVisitor/DefinedSymbolCollectorFunctionalTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ComposerRequireCheckerTest\NodeVisitor;
 
 use ComposerRequireChecker\NodeVisitor\DefinedSymbolCollector;
+use Override;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeTraverserInterface;
@@ -29,6 +30,7 @@ final class DefinedSymbolCollectorFunctionalTest extends TestCase
 
     private NodeTraverserInterface $traverser;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->collector = new DefinedSymbolCollector();
@@ -105,12 +107,12 @@ final class DefinedSymbolCollectorFunctionalTest extends TestCase
     {
         $this->traverseStringAST(<<<'PHP'
             namespace Foo {
-        
+
             function define($bar, $baz)
             {
                 return;
             }
-        
+
             define("NOT_A_CONST", "NOT_SOMETHING");
             }
         PHP);
@@ -125,14 +127,14 @@ final class DefinedSymbolCollectorFunctionalTest extends TestCase
     {
         $this->traverseStringAST(<<<'PHP'
             namespace Foo;
-            
+
             trait BarTrait
             {
                 protected function test()
                 {
                 }
             }
-            
+
             class UseTrait
             {
                 use BarTrait {

--- a/test/ComposerRequireCheckerTest/NodeVisitor/DefinedSymbolCollectorTest.php
+++ b/test/ComposerRequireCheckerTest/NodeVisitor/DefinedSymbolCollectorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ComposerRequireCheckerTest\NodeVisitor;
 
 use ComposerRequireChecker\NodeVisitor\DefinedSymbolCollector;
+use Override;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Identifier;
@@ -28,6 +29,7 @@ final class DefinedSymbolCollectorTest extends TestCase
 
     private NodeTraverserInterface $traverser;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->collector = new DefinedSymbolCollector();

--- a/test/ComposerRequireCheckerTest/NodeVisitor/UsedSymbolCollectorFunctionalTest.php
+++ b/test/ComposerRequireCheckerTest/NodeVisitor/UsedSymbolCollectorFunctionalTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ComposerRequireCheckerTest\NodeVisitor;
 
 use ComposerRequireChecker\NodeVisitor\UsedSymbolCollector;
+use Override;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeTraverserInterface;
@@ -29,6 +30,7 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
 
     private NodeTraverserInterface $traverser;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->collector = new UsedSymbolCollector();
@@ -45,6 +47,7 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
 
         self::assertSameCollectedSymbols(
             [
+                'Override',
                 'ComposerRequireChecker\NodeVisitor\UsedSymbolCollector',
                 'PHPUnit\Framework\TestCase',
                 'PhpParser\NodeTraverser',
@@ -144,16 +147,16 @@ final class UsedSymbolCollectorFunctionalTest extends TestCase
     {
         $this->traverseStringAST(<<<'PHP'
         <?php
-        
+
         namespace Foo;
-        
+
         trait BarTrait
         {
             protected function test()
             {
             }
         }
-        
+
         class UseTrait
         {
             use BarTrait {

--- a/test/ComposerRequireCheckerTest/NodeVisitor/UsedSymbolCollectorTest.php
+++ b/test/ComposerRequireCheckerTest/NodeVisitor/UsedSymbolCollectorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ComposerRequireCheckerTest\NodeVisitor;
 
 use ComposerRequireChecker\NodeVisitor\UsedSymbolCollector;
+use Override;
 use PhpParser\Modifiers;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\ConstFetch;
@@ -34,6 +35,7 @@ final class UsedSymbolCollectorTest extends TestCase
 {
     private UsedSymbolCollector $visitor;
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/test/ComposerRequireCheckerTest/PharTest.php
+++ b/test/ComposerRequireCheckerTest/PharTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ComposerRequireCheckerTest;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 
 use function chdir;
@@ -23,6 +24,7 @@ final class PharTest extends TestCase
     private string $bin;
     private string $oldWorkingDirectory;
 
+    #[Override]
     protected function setUp(): void
     {
         $phar = realpath(dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'build' . DIRECTORY_SEPARATOR . 'composer-require-checker.phar');
@@ -35,6 +37,7 @@ final class PharTest extends TestCase
         $this->bin                 = PHP_BINARY . ' ' . escapeshellarg($phar);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         if ($this->oldWorkingDirectory === getcwd()) {

--- a/test/ComposerRequireCheckerTest/UsedSymbolsLocator/LocateUsedSymbolsFromASTRootsTest.php
+++ b/test/ComposerRequireCheckerTest/UsedSymbolsLocator/LocateUsedSymbolsFromASTRootsTest.php
@@ -6,6 +6,7 @@ namespace ComposerRequireCheckerTest\UsedSymbolsLocator;
 
 use ArrayObject;
 use ComposerRequireChecker\UsedSymbolsLocator\LocateUsedSymbolsFromASTRoots;
+use Override;
 use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
@@ -19,6 +20,7 @@ final class LocateUsedSymbolsFromASTRootsTest extends TestCase
 {
     private LocateUsedSymbolsFromASTRoots $locator;
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
In Psalm version 6.6.0, the MissingOverrideAttribute rule was enabled for all PHP versions.

This should fix some of the test failures in https://github.com/maglnet/ComposerRequireChecker/pull/569