### PR TITLE
Avoid InvalidOperand error from psalm

### DIFF
--- a/src/ComposerRequireChecker/Cli/CheckCommand.php
+++ b/src/ComposerRequireChecker/Cli/CheckCommand.php
@@ -144,13 +144,13 @@ class CheckCommand extends Command
             (new LocateDefinedSymbolsFromComposerRuntimeApi())->__invoke($composerData),
         );
 
-        $this->verbose('found ' . count($definedVendorSymbols) . ' symbols.', $output, true);
+        $this->verbose(sprintf('found %d symbols.', count($definedVendorSymbols)), $output, true);
 
         $this->verbose('Collecting defined extension symbols... ', $output);
         $definedExtensionSymbols = (new LocateDefinedSymbolsFromExtensions())->__invoke(
             (new DefinedExtensionsResolver())->__invoke($composerJson, $options->getPhpCoreExtensions()),
         );
-        $this->verbose('found ' . count($definedExtensionSymbols) . ' symbols.', $output, true);
+        $this->verbose(sprintf('found %d symbols.', count($definedExtensionSymbols)), $output, true);
 
         $this->verbose('Collecting used symbols... ', $output);
         $usedSymbols = (new LocateUsedSymbolsFromASTRoots())->__invoke(
@@ -161,7 +161,7 @@ class CheckCommand extends Command
                 ),
             ),
         );
-        $this->verbose('found ' . count($usedSymbols) . ' symbols.', $output, true);
+        $this->verbose(sprintf('found %d symbols.', count($usedSymbols)), $output, true);
 
         if (! count($usedSymbols)) {
             throw new LogicException('There were no symbols found, please check your configuration.');

--- a/src/ComposerRequireChecker/Cli/ResultsWriter/CliText.php
+++ b/src/ComposerRequireChecker/Cli/ResultsWriter/CliText.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function count;
 use function implode;
+use function sprintf;
 
 final class CliText implements ResultsWriter
 {
@@ -36,7 +37,7 @@ final class CliText implements ResultsWriter
             return;
         }
 
-        $this->output->writeln('The following ' . count($unknownSymbols) . ' unknown symbols were found:');
+        $this->output->writeln(sprintf('The following %d unknown symbols were found:', count($unknownSymbols)));
 
         $tableOutput = new BufferedOutput();
         $table       = new Table($tableOutput);


### PR DESCRIPTION
Since Psalm version 6.7.0, invalid operands are now more strictly reported.

This should fix some of the test failures in https://github.com/maglnet/ComposerRequireChecker/pull/569