### PR TITLE
Add --dev flag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ phive install composer-require-checker
 This package can be easily globally installed by using [Composer]:
 
 ```sh
-composer global require maglnet/composer-require-checker
+composer global require maglnet/composer-require-checker --dev
 ```
 
 If you haven't already setup your composer installation to support global requirements, please refer to the [Composer CLI - global]


### PR DESCRIPTION
Composer recommends the package is installed as a dev dependency so it makes since to add this to the README.

> The package you required is recommended to be placed in require-dev (because it is tagged as "static analysis") but you did not use --dev.
