### PR TITLE
Update revolt/event-loop from 1.0.7 to 1.0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,9 @@
         "spatie/temporary-directory": "^2.3.0",
         "vimeo/psalm": "^6.13.0"
     },
+    "conflict": {
+        "revolt/event-loop": "< 1.0.8"
+    },
     "config": {
         "optimize-autoloader": true,
         "sort-packages": true,

--- a/composer.lock
+++ b/composer.lock
@@ -195,16 +195,16 @@
         },
         {
             "name": "revolt/event-loop",
-            "version": "v1.0.7",
+            "version": "v1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "09bf1bf7f7f574453efe43044b06fafe12216eb3"
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/09bf1bf7f7f574453efe43044b06fafe12216eb3",
-                "reference": "09bf1bf7f7f574453efe43044b06fafe12216eb3",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
                 "shasum": ""
             },
             "require": {
@@ -261,9 +261,9 @@
             ],
             "support": {
                 "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.7"
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
             },
-            "time": "2025-01-25T19:27:39+00:00"
+            "time": "2025-08-27T21:33:23+00:00"
         },
         {
             "name": "symfony/console",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73e577faad1e5fcc7f3f40720a94c201",
+    "content-hash": "1a6c80768bd7c73b2ef30de5e9213ebb",
     "packages": [
         {
             "name": "azjezz/psl",


### PR DESCRIPTION
This includes the fix from https://github.com/revoltphp/event-loop/pull/110, and should make a PHP 8.5 deprecation notice go away that is displayed with the latest PHP versions:

> Deprecated: Increment on non-numeric string is deprecated, use str_increment() instead in /composer-require-checker/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php on line 182
