### PR TITLE
feat: Add opt-in scanning of files required by autoload.files entries

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -1,0 +1,3 @@
+{
+    "scan-files-from-autoload-requires": true
+}

--- a/src/ComposerRequireChecker/Cli/CheckCommand.php
+++ b/src/ComposerRequireChecker/Cli/CheckCommand.php
@@ -79,6 +79,12 @@ class CheckCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'generate output either as "text" or as "json", if specified, "quiet mode" is implied',
+            )
+            ->addOption(
+                'scan-autoload-requires',
+                null,
+                InputOption::VALUE_NONE,
+                'scan PHP files required by autoload.files entries to discover transitively defined symbols',
             );
     }
 
@@ -123,6 +129,10 @@ class CheckCommand extends Command
 
         $options = $this->getCheckOptions($input);
 
+        if ($input->getOption('scan-autoload-requires')) {
+            $options->setScanFilesFromAutoloadRequires(true);
+        }
+
         $getPackageSourceFiles    = new LocateComposerPackageSourceFiles();
         $getAdditionalSourceFiles = new LocateFilesByGlobPattern();
 
@@ -135,7 +145,7 @@ class CheckCommand extends Command
                     (new ComposeGenerators())->__invoke(
                         $getAdditionalSourceFiles($options->getScanFiles(), dirname($composerJson)),
                         $getPackageSourceFiles($composerData, dirname($composerJson)),
-                        (new LocateComposerPackageDirectDependenciesSourceFiles())->__invoke($composerJson),
+                        (new LocateComposerPackageDirectDependenciesSourceFiles($options->getScanFilesFromAutoloadRequires()))->__invoke($composerJson),
                     ),
                 ),
             ),

--- a/src/ComposerRequireChecker/Cli/Options.php
+++ b/src/ComposerRequireChecker/Cli/Options.php
@@ -73,6 +73,8 @@ class Options
      */
     private array $scanFiles = [];
 
+    private bool $scanFilesFromAutoloadRequires = false;
+
     /** @param array<string, mixed> $options */
     public function __construct(array $options = [])
     {
@@ -133,6 +135,16 @@ class Options
     public function setScanFiles(array $scanFiles): void
     {
         $this->scanFiles = $scanFiles;
+    }
+
+    public function getScanFilesFromAutoloadRequires(): bool
+    {
+        return $this->scanFilesFromAutoloadRequires;
+    }
+
+    public function setScanFilesFromAutoloadRequires(bool $scanFilesFromAutoloadRequires): void
+    {
+        $this->scanFilesFromAutoloadRequires = $scanFilesFromAutoloadRequires;
     }
 
     private function getCamelCase(string $string): string

--- a/src/ComposerRequireChecker/FileLocator/LocateComposerPackageDirectDependenciesSourceFiles.php
+++ b/src/ComposerRequireChecker/FileLocator/LocateComposerPackageDirectDependenciesSourceFiles.php
@@ -13,6 +13,8 @@ use Psl\Type;
 
 use function array_key_exists;
 use function array_keys;
+use function ltrim;
+use function str_replace;
 
 /**
  * @psalm-import-type ComposerAutoload from JsonLoader
@@ -20,6 +22,10 @@ use function array_keys;
  */
 final class LocateComposerPackageDirectDependenciesSourceFiles
 {
+    public function __construct(private readonly bool $scanFilesFromAutoloadRequires = false)
+    {
+    }
+
     /** @return Generator<string> */
     public function __invoke(string $composerJsonPath): Generator
     {
@@ -35,12 +41,25 @@ final class LocateComposerPackageDirectDependenciesSourceFiles
 
         $installedPackages = $this->getInstalledPackages($packageDir . '/' . $configVendorDir);
 
+        $locateViaRequires = $this->scanFilesFromAutoloadRequires
+            ? new LocateFilesViaRequireStatements()
+            : null;
+
         foreach ($vendorDirs as $vendorName => $vendorDir) {
             if (! array_key_exists($vendorName, $installedPackages)) {
                 continue;
             }
 
-            yield from (new LocateComposerPackageSourceFiles())->__invoke(['autoload' => $installedPackages[$vendorName]], $vendorDir);
+            $autoload = $installedPackages[$vendorName];
+
+            yield from (new LocateComposerPackageSourceFiles())->__invoke(['autoload' => $autoload], $vendorDir);
+
+            if ($locateViaRequires !== null) {
+                foreach ($autoload['files'] ?? [] as $file) {
+                    $filePath = str_replace('\\', '/', $vendorDir . '/' . ltrim($file, '/'));
+                    yield from $locateViaRequires($filePath);
+                }
+            }
         }
     }
 

--- a/src/ComposerRequireChecker/FileLocator/LocateFilesViaRequireStatements.php
+++ b/src/ComposerRequireChecker/FileLocator/LocateFilesViaRequireStatements.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerRequireChecker\FileLocator;
+
+use Generator;
+use PhpParser\Error;
+use PhpParser\ErrorHandler\Collecting as CollectingErrorHandler;
+use PhpParser\Node;
+use PhpParser\NodeFinder;
+use PhpParser\ParserFactory;
+use Psl\File;
+use Psl\Filesystem;
+use Psl\Type;
+
+use function is_file;
+use function ltrim;
+use function str_replace;
+
+final class LocateFilesViaRequireStatements
+{
+    /** @return Generator<string> */
+    public function __invoke(string $filePath): Generator
+    {
+        if (! is_file($filePath)) {
+            return;
+        }
+
+        $path = Type\non_empty_string()->coerce($filePath);
+
+        try {
+            $content = File\read($path);
+        } catch (File\Exception\NotFoundException) {
+            return;
+        }
+
+        $errorHandler = new CollectingErrorHandler();
+        $parser       = (new ParserFactory())->createForNewestSupportedVersion();
+
+        try {
+            $stmts = $parser->parse($content, $errorHandler);
+        } catch (Error) {
+            return;
+        }
+
+        if ($stmts === null) {
+            return;
+        }
+
+        $fileDir = Filesystem\get_directory($path);
+
+        /** @var Node\Expr\Include_[] $includes */
+        $includes = (new NodeFinder())->findInstanceOf($stmts, Node\Expr\Include_::class);
+
+        foreach ($includes as $include) {
+            $resolvedPath = $this->resolvePath($include->expr, $fileDir);
+
+            if ($resolvedPath !== null && is_file($resolvedPath)) {
+                yield $resolvedPath;
+            }
+        }
+    }
+
+    private function resolvePath(Node\Expr $expr, string $fileDir): ?string
+    {
+        if ($expr instanceof Node\Scalar\String_) {
+            return $this->normalizePath($fileDir . '/' . ltrim($expr->value, '/'));
+        }
+
+        if (
+            $expr instanceof Node\Expr\BinaryOp\Concat
+            && $expr->left instanceof Node\Scalar\MagicConst\Dir
+            && $expr->right instanceof Node\Scalar\String_
+        ) {
+            return $this->normalizePath($fileDir . $expr->right->value);
+        }
+
+        return null;
+    }
+
+    private function normalizePath(string $path): string
+    {
+        // @infection-ignore-all UnwrapStrReplace False positive on Linux; this guards against Windows paths.
+        return str_replace('\\', '/', $path);
+    }
+}

--- a/test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php
+++ b/test/ComposerRequireCheckerTest/Cli/CheckCommandTest.php
@@ -236,6 +236,276 @@ JSON
         );
     }
 
+    public function testNoUnknownSymbolsFoundForDirectDependencyFunction(): void
+    {
+        $root = (new TemporaryDirectory())
+            ->deleteWhenDestroyed()
+            ->create();
+
+        file_put_contents(
+            $root->path('composer.json'),
+            <<<'JSON'
+{
+    "require": {
+        "php": "^8.4",
+        "foo/bar": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Example\\Library\\": "src/"
+        }
+    }
+}
+JSON
+        );
+        file_put_contents(
+            $root->path('vendor/composer/installed.json'),
+            <<<'JSON'
+{
+    "packages": [
+        {
+            "name": "foo/bar",
+            "autoload": {
+                "files": ["functions.php"]
+            }
+        }
+    ]
+}
+JSON
+        );
+        file_put_contents(
+            $root->path('vendor/foo/bar/functions.php'),
+            <<<'PHP'
+<?php
+
+namespace Foo\Bar;
+
+function helper(): string
+{
+    return 'value';
+}
+PHP
+        );
+        file_put_contents(
+            $root->path('src/SomeClass.php'),
+            <<<'PHP'
+<?php
+
+namespace Example\Library;
+
+use function Foo\Bar\helper;
+
+final class SomeClass
+{
+    public function someMethod(): string
+    {
+        return helper();
+    }
+}
+PHP
+        );
+
+        $this->commandTester->execute([
+            'composer-json' => $root->path('composer.json'),
+        ]);
+
+        self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        self::assertStringContainsString(
+            'There were no unknown symbols found.',
+            $this->commandTester->getDisplay(),
+        );
+    }
+
+    public function testNoUnknownSymbolsFoundForTransitiveAutoloadFilesFunction(): void
+    {
+        $root = (new TemporaryDirectory())
+            ->deleteWhenDestroyed()
+            ->create();
+
+        file_put_contents(
+            $root->path('composer.json'),
+            <<<'JSON'
+{
+    "require": {
+        "php": "^8.4",
+        "foo/bar": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Example\\Library\\": "src/"
+        }
+    }
+}
+JSON
+        );
+        file_put_contents(
+            $root->path('vendor/composer/installed.json'),
+            <<<'JSON'
+{
+    "packages": [
+        {
+            "name": "foo/bar",
+            "autoload": {
+                "files": ["bootstrap.php"]
+            }
+        }
+    ]
+}
+JSON
+        );
+        file_put_contents(
+            $root->path('vendor/foo/bar/bootstrap.php'),
+            <<<'PHP'
+<?php
+require __DIR__ . '/functions.php';
+PHP
+        );
+        file_put_contents(
+            $root->path('vendor/foo/bar/functions.php'),
+            <<<'PHP'
+<?php
+
+namespace Foo\Bar;
+
+function helper(): string
+{
+    return 'value';
+}
+PHP
+        );
+        file_put_contents(
+            $root->path('src/SomeClass.php'),
+            <<<'PHP'
+<?php
+
+namespace Example\Library;
+
+use function Foo\Bar\helper;
+
+final class SomeClass
+{
+    public function someMethod(): string
+    {
+        return helper();
+    }
+}
+PHP
+        );
+
+        $this->commandTester->execute([
+            'composer-json'          => $root->path('composer.json'),
+            '--scan-autoload-requires' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        self::assertStringContainsString(
+            'There were no unknown symbols found.',
+            $this->commandTester->getDisplay(),
+        );
+    }
+
+    public function testNoUnknownSymbolsFoundForConditionalRequireInAutoloadFiles(): void
+    {
+        $root = (new TemporaryDirectory())
+            ->deleteWhenDestroyed()
+            ->create();
+
+        file_put_contents(
+            $root->path('composer.json'),
+            <<<'JSON'
+{
+    "require": {
+        "php": "^8.4",
+        "foo/bar": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Example\\Library\\": "src/"
+        }
+    }
+}
+JSON
+        );
+        file_put_contents(
+            $root->path('vendor/composer/installed.json'),
+            <<<'JSON'
+{
+    "packages": [
+        {
+            "name": "foo/bar",
+            "autoload": {
+                "files": ["generated/url.php"]
+            }
+        }
+    ]
+}
+JSON
+        );
+        file_put_contents(
+            $root->path('vendor/foo/bar/generated/url.php'),
+            <<<'PHP'
+<?php
+if (str_starts_with(PHP_VERSION, "8.1.")) {
+    require_once __DIR__ . '/8.1/url.php';
+}
+if (str_starts_with(PHP_VERSION, "8.2.")) {
+    require_once __DIR__ . '/8.1/url.php';
+}
+if (str_starts_with(PHP_VERSION, "8.3.")) {
+    require_once __DIR__ . '/8.1/url.php';
+}
+if (str_starts_with(PHP_VERSION, "8.4.")) {
+    require_once __DIR__ . '/8.1/url.php';
+}
+if (str_starts_with(PHP_VERSION, "8.5.")) {
+    require_once __DIR__ . '/8.1/url.php';
+}
+PHP
+        );
+        file_put_contents(
+            $root->path('vendor/foo/bar/generated/8.1/url.php'),
+            <<<'PHP'
+<?php
+
+namespace Foo\Bar;
+
+function base64_decode(string $string): string
+{
+    return \base64_decode($string, true) ?: throw new \RuntimeException('Invalid base64');
+}
+PHP
+        );
+        file_put_contents(
+            $root->path('src/SomeClass.php'),
+            <<<'PHP'
+<?php
+
+namespace Example\Library;
+
+use function Foo\Bar\base64_decode;
+
+final class SomeClass
+{
+    public function decode(string $input): string
+    {
+        return base64_decode($input);
+    }
+}
+PHP
+        );
+
+        $this->commandTester->execute([
+            'composer-json'            => $root->path('composer.json'),
+            '--scan-autoload-requires' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $this->commandTester->getStatusCode());
+        self::assertStringContainsString(
+            'There were no unknown symbols found.',
+            $this->commandTester->getDisplay(),
+        );
+    }
+
     public function testUnknownComposerSymbolFound(): void
     {
         $this->commandTester->execute([

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageDirectDependenciesSourceFilesTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateComposerPackageDirectDependenciesSourceFilesTest.php
@@ -126,10 +126,64 @@ final class LocateComposerPackageDirectDependenciesSourceFilesTest extends TestC
         $this->assertFalse(file_exists($this->path('vendor/foo/bar/composer.json')));
     }
 
+    public function testAutoloadFilesRequiresAreNotFollowedByDefault(): void
+    {
+        file_put_contents($this->path('composer.json'), '{"require":{"foo/bar": "^1.0"}}');
+        file_put_contents(
+            $this->path('vendor/composer/installed.json'),
+            '{"packages":[{"name": "foo/bar", "autoload":{"files":["bootstrap.php"]}}]}',
+        );
+        file_put_contents(
+            $this->path('vendor/foo/bar/bootstrap.php'),
+            '<?php require __DIR__ . \'/functions.php\';',
+        );
+        file_put_contents($this->path('vendor/foo/bar/functions.php'), '<?php function foo() {}');
+
+        $files = $this->locate($this->path('composer.json'));
+
+        $this->assertNotContains(
+            str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $this->path('vendor/foo/bar/functions.php')),
+            array_map(
+                static fn (string $f): string => str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $f),
+                $files,
+            ),
+        );
+    }
+
+    public function testAutoloadFilesRequiresAreFollowedWhenEnabled(): void
+    {
+        file_put_contents($this->path('composer.json'), '{"require":{"foo/bar": "^1.0"}}');
+        file_put_contents(
+            $this->path('vendor/composer/installed.json'),
+            '{"packages":[{"name": "foo/bar", "autoload":{"files":["bootstrap.php"]}}]}',
+        );
+        file_put_contents(
+            $this->path('vendor/foo/bar/bootstrap.php'),
+            '<?php require __DIR__ . \'/functions.php\';',
+        );
+        file_put_contents($this->path('vendor/foo/bar/functions.php'), '<?php function foo() {}');
+
+        $files = $this->locateWithRequireScanning($this->path('composer.json'));
+
+        $this->assertContains(
+            str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $this->path('vendor/foo/bar/functions.php')),
+            array_map(
+                static fn (string $f): string => str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $f),
+                $files,
+            ),
+        );
+    }
+
     /** @return string[] */
     private function locate(string $composerJson): array
     {
         return iterator_to_array(($this->locator)($composerJson));
+    }
+
+    /** @return string[] */
+    private function locateWithRequireScanning(string $composerJson): array
+    {
+        return iterator_to_array((new LocateComposerPackageDirectDependenciesSourceFiles(true))($composerJson));
     }
 
     private function path(string $path): string

--- a/test/ComposerRequireCheckerTest/FileLocator/LocateFilesViaRequireStatementsTest.php
+++ b/test/ComposerRequireCheckerTest/FileLocator/LocateFilesViaRequireStatementsTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerRequireCheckerTest\FileLocator;
+
+use ComposerRequireChecker\FileLocator\LocateFilesViaRequireStatements;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Spatie\TemporaryDirectory\TemporaryDirectory;
+
+use function array_map;
+use function file_put_contents;
+use function iterator_to_array;
+use function str_replace;
+
+use const DIRECTORY_SEPARATOR;
+
+#[CoversClass(LocateFilesViaRequireStatements::class)]
+final class LocateFilesViaRequireStatementsTest extends TestCase
+{
+    private LocateFilesViaRequireStatements $locator;
+    private TemporaryDirectory $root;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->locator = new LocateFilesViaRequireStatements();
+        $this->root    = (new TemporaryDirectory())
+            ->deleteWhenDestroyed()
+            ->create();
+    }
+
+    public function testNonExistentFileYieldsNothing(): void
+    {
+        $files = $this->locate($this->path('nonexistent.php'));
+
+        $this->assertCount(0, $files);
+    }
+
+    public function testFileWithNoRequiresYieldsNothing(): void
+    {
+        file_put_contents($this->path('bootstrap.php'), '<?php function foo() {}');
+
+        $files = $this->locate($this->path('bootstrap.php'));
+
+        $this->assertCount(0, $files);
+    }
+
+    public function testFollowsTopLevelDirConcatRequire(): void
+    {
+        file_put_contents(
+            $this->path('bootstrap.php'),
+            '<?php require __DIR__ . \'/functions.php\';',
+        );
+        file_put_contents($this->path('functions.php'), '<?php function foo() {}');
+
+        $files = $this->locate($this->path('bootstrap.php'));
+
+        $this->assertCount(1, $files);
+        $this->assertContains($this->path('functions.php'), $this->normalizeFiles($files));
+    }
+
+    public function testFollowsTopLevelRequireOnce(): void
+    {
+        file_put_contents(
+            $this->path('bootstrap.php'),
+            '<?php require_once __DIR__ . \'/functions.php\';',
+        );
+        file_put_contents($this->path('functions.php'), '<?php function foo() {}');
+
+        $files = $this->locate($this->path('bootstrap.php'));
+
+        $this->assertCount(1, $files);
+        $this->assertContains($this->path('functions.php'), $this->normalizeFiles($files));
+    }
+
+    public function testFollowsPlainStringRequire(): void
+    {
+        file_put_contents(
+            $this->path('bootstrap.php'),
+            '<?php require \'functions.php\';',
+        );
+        file_put_contents($this->path('functions.php'), '<?php function foo() {}');
+
+        $files = $this->locate($this->path('bootstrap.php'));
+
+        $this->assertCount(1, $files);
+        $this->assertContains($this->path('functions.php'), $this->normalizeFiles($files));
+    }
+
+    public function testFollowsRequireInsideIfBlock(): void
+    {
+        file_put_contents(
+            $this->path('bootstrap.php'),
+            <<<'PHP'
+<?php
+if (str_starts_with(PHP_VERSION, "8.1.")) {
+    require_once __DIR__ . '/8.1/functions.php';
+}
+if (str_starts_with(PHP_VERSION, "8.2.")) {
+    require_once __DIR__ . '/8.2/functions.php';
+}
+PHP,
+        );
+        file_put_contents($this->path('8.1/functions.php'), '<?php function foo81() {}');
+        file_put_contents($this->path('8.2/functions.php'), '<?php function foo82() {}');
+
+        $files = $this->normalizeFiles($this->locate($this->path('bootstrap.php')));
+
+        $this->assertContains($this->path('8.1/functions.php'), $files);
+        $this->assertContains($this->path('8.2/functions.php'), $files);
+    }
+
+    public function testFollowsReturnRequireInsideIfBlock(): void
+    {
+        file_put_contents(
+            $this->path('bootstrap.php'),
+            <<<'PHP'
+<?php
+if (\PHP_VERSION_ID >= 80000) {
+    return require __DIR__ . '/bootstrap80.php';
+}
+function legacyFoo() {}
+PHP,
+        );
+        file_put_contents($this->path('bootstrap80.php'), '<?php function modernFoo() {}');
+
+        $files = $this->normalizeFiles($this->locate($this->path('bootstrap.php')));
+
+        $this->assertContains($this->path('bootstrap80.php'), $files);
+    }
+
+    public function testMultipleRequiresYieldsMultipleFiles(): void
+    {
+        file_put_contents(
+            $this->path('bootstrap.php'),
+            <<<'PHP'
+<?php
+require __DIR__ . '/a.php';
+require __DIR__ . '/b.php';
+require __DIR__ . '/c.php';
+PHP,
+        );
+        file_put_contents($this->path('a.php'), '<?php function a() {}');
+        file_put_contents($this->path('b.php'), '<?php function b() {}');
+        file_put_contents($this->path('c.php'), '<?php function c() {}');
+
+        $files = $this->locate($this->path('bootstrap.php'));
+
+        $this->assertCount(3, $files);
+    }
+
+    public function testNonExistentRequiredFileIsSkipped(): void
+    {
+        file_put_contents(
+            $this->path('bootstrap.php'),
+            '<?php require __DIR__ . \'/does_not_exist.php\';',
+        );
+
+        $files = $this->locate($this->path('bootstrap.php'));
+
+        $this->assertCount(0, $files);
+    }
+
+    public function testDynamicRequireWithVariableIsIgnored(): void
+    {
+        file_put_contents(
+            $this->path('bootstrap.php'),
+            '<?php $file = "functions.php"; require $file;',
+        );
+        file_put_contents($this->path('functions.php'), '<?php function foo() {}');
+
+        $files = $this->locate($this->path('bootstrap.php'));
+
+        $this->assertCount(0, $files);
+    }
+
+    /** @return string[] */
+    private function locate(string $filePath): array
+    {
+        return iterator_to_array(($this->locator)($filePath));
+    }
+
+    /** @param string[] $files */
+    private function normalizeFiles(array $files): array
+    {
+        return array_map(
+            static fn (string $f): string => str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $f),
+            $files,
+        );
+    }
+
+    private function path(string $path): string
+    {
+        $path = str_replace('/', DIRECTORY_SEPARATOR, $path);
+
+        return $this->root->path($path);
+    }
+}


### PR DESCRIPTION
Hello!

thanks for your work in this package!
I wanted to give it a try to see if I can fix an issue that I have since some time about the usage of vendors' `functions`.
Similar also to https://github.com/maglnet/ComposerRequireChecker/issues/179

Some packages expose symbols (functions, constants) via `autoload.files` bootstrap files that only `require` other files rather than defining symbols directly. 
Common examples are libs like `lambdish/phunctional`, `thecodingmachine/safe`, and Symfony polyfills etc.

`composer-require-checker` scanned the bootstrap file but found no symbols there, causing false positives for packages that are correct direct dependencies: https://github.com/maglnet/ComposerRequireChecker/issues/575 is another example.
  
To add this capability, I added `LocateFilesViaRequireStatements`, a file locator that parses a PHP file with PHP-Parser and yields any resolvable file paths found in `require` / `require_once` expressions — at any AST depth (top-level, inside `if` blocks, `return require`, etc.).

`LocateComposerPackageDirectDependenciesSourceFiles` now optionally runs this locator over each `autoload.files` entry to discover transitively included files.

To not impact any existing usage, I added the additional scans via the `scan-autoload-requires` flag (default `false`):
* Config file: `"scan-files-from-autoload-requires": true`
* CLI flag: `--scan-autoload-requires`

Following table explains the patterns covered (I think I covered all of them, any comment is highly appreciated)
| Pattern | Example |
|---------|---------|
| Top-level `require __DIR__ . '/path.php'` | lambdish/phunctional |
| `require_once` inside an `if` block | thecodingmachine/safe |
| `return require` inside an `if` block | Symfony polyfills |
| Plain string literal `require 'path.php'` | generic |

I hope you'll find this feature useful 🚀 